### PR TITLE
footer 리뉴얼 및 모바일 nav 하단 액션 정리

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -4,7 +4,7 @@
   display: none;
 }
 
-.header-close--floating {
+.header-nav__actions {
   display: none;
 }
 
@@ -493,10 +493,10 @@
     width: min(420px, 100vw);
     height: var(--header-nav-height, 100dvh);
     max-height: var(--header-nav-height, 100dvh);
-    padding: 24px 20px calc(88px + env(safe-area-inset-bottom, 0px));
+    padding: 24px 20px 0;
     background-color: #f6f5ef;
     overflow-y: auto;
-    scroll-padding-bottom: calc(88px + env(safe-area-inset-bottom, 0px));
+    scroll-padding-bottom: calc(104px + env(safe-area-inset-bottom, 0px));
     -webkit-overflow-scrolling: touch;
     overscroll-behavior: contain;
     touch-action: pan-y;
@@ -535,49 +535,90 @@
     align-self: flex-end;
   }
 
-  header .header-close--floating {
-    position: fixed;
-    left: 50%;
-    bottom: calc(4px + env(safe-area-inset-bottom, 0px));
+  header .header-nav__actions {
+    position: sticky;
+    bottom: 0;
+    display: none;
+    gap: 12px;
+    margin: 12px -20px 0;
+    padding: 20px 20px calc(18px + env(safe-area-inset-bottom, 0px));
+    border-top: 1px solid rgba(30, 57, 50, 0.08);
+    background:
+      linear-gradient(
+        180deg,
+        rgba(246, 245, 239, 0) 0%,
+        rgba(246, 245, 239, 0.88) 26%,
+        rgba(246, 245, 239, 0.96) 50%,
+        rgba(246, 245, 239, 1) 100%
+      );
+    box-shadow: 0 -12px 24px -20px rgba(47, 36, 28, 0.35);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    isolation: isolate;
+    z-index: 3;
+  }
+
+  header.is-nav-actions-visible .header-nav__actions {
+    display: grid;
+  }
+
+  header .header-nav__actions::before {
+    content: "";
+    justify-self: center;
+    width: min(68px, 18vw);
+    height: 1px;
+    background:
+      linear-gradient(
+        90deg,
+        rgba(30, 57, 50, 0),
+        rgba(30, 57, 50, 0.22),
+        rgba(30, 57, 50, 0)
+      );
+  }
+
+  header .header-nav__close-action {
+    appearance: none;
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 56px;
-    height: 56px;
-    padding: 0;
-    border: 1px solid rgba(0, 98, 65, 0.14);
-    border-radius: 999px;
-    background: linear-gradient(180deg, rgba(246, 245, 239, 0.98) 0%, rgba(236, 244, 239, 0.98) 100%);
-    color: #006241;
-    box-shadow: 0 14px 28px rgba(30, 57, 50, 0.16);
-    transform: translate(-50%, calc(100% + 18px)) scale(0.96);
-    opacity: 0;
-    visibility: hidden;
-    pointer-events: none;
-    z-index: 10002;
-    will-change: transform, opacity;
+    width: min(100%, 304px);
+    min-height: 48px;
+    margin: 0 auto;
+    padding: 0 20px;
+    border: 1px solid rgba(17, 45, 38, 0.14);
+    border-radius: 13px;
+    background-color: #214338;
+    color: #f8f6f0;
+    font: inherit;
+    font-size: 13.5px;
+    font-weight: 600;
+    line-height: 1.1;
+    letter-spacing: -0.015em;
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.06),
+      0 6px 16px rgba(17, 45, 38, 0.12);
     transition:
-      opacity 0.28s ease,
-      visibility 0.28s ease,
-      transform 0.36s cubic-bezier(0.22, 1, 0.36, 1),
-      box-shadow 0.24s ease;
+      background-color 0.2s ease,
+      transform 0.2s ease,
+      border-color 0.2s ease,
+      box-shadow 0.2s ease;
   }
 
-  header .header-close--floating .material-icons {
-    font-size: 24px;
-    line-height: 1;
+  header .header-nav__close-action:active {
+    transform: translateY(1px);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.06),
+      0 4px 10px rgba(17, 45, 38, 0.1);
   }
 
-  header.is-nav-open.is-bottom-close-visible .header-close--floating {
-    opacity: 1;
-    visibility: visible;
-    pointer-events: auto;
-    transform: translate(-50%, 0) scale(1);
+  header .header-nav__close-action:focus-visible {
+    outline: 2px solid #006241;
+    outline-offset: 3px;
   }
 
-  header.is-nav-open.is-bottom-close-visible .header-close--floating:active,
-  header.is-nav-open.is-bottom-close-visible .header-close--floating:focus-visible {
-    box-shadow: 0 10px 20px rgba(30, 57, 50, 0.14);
+  header .header-nav__close-action:hover {
+    background-color: #25493e;
+    border-color: rgba(17, 45, 38, 0.2);
   }
 
   header .header-quick-links {
@@ -692,6 +733,10 @@
     position: static;
     display: block;
     padding-top: 20px;
+  }
+
+  header.is-nav-actions-visible .main-menu {
+    padding-bottom: 18px;
   }
 
   header .main-menu .item--whats-new {
@@ -1645,8 +1690,8 @@
 
   header .header-nav {
     width: 100vw;
-    padding: 20px 16px calc(76px + env(safe-area-inset-bottom, 0px));
-    scroll-padding-bottom: calc(76px + env(safe-area-inset-bottom, 0px));
+    padding: 20px 16px 0;
+    scroll-padding-bottom: calc(96px + env(safe-area-inset-bottom, 0px));
   }
 
   header .header-nav__top {
@@ -1654,10 +1699,18 @@
     padding-bottom: 16px;
   }
 
-  header .header-close--floating {
-    bottom: calc(3px + env(safe-area-inset-bottom, 0px));
-    width: 52px;
-    height: 52px;
+  header .header-nav__actions {
+    gap: 10px;
+    margin: 10px -16px 0;
+    padding: 18px 16px calc(16px + env(safe-area-inset-bottom, 0px));
+  }
+
+  header .header-nav__close-action {
+    width: min(100%, 292px);
+    min-height: 46px;
+    padding: 0 18px;
+    font-size: 13px;
+    border-radius: 12px;
   }
 
   header .header-quick-link {
@@ -1695,6 +1748,10 @@
 
   header .main-menu {
     padding-top: 16px;
+  }
+
+  header.is-nav-actions-visible .main-menu {
+    padding-bottom: 16px;
   }
 
   header .main-menu .item > .item__name {
@@ -1812,7 +1869,9 @@
   }
 
   .mobile-flow-footer__title {
-    font-size: 15.5px;
+    margin-bottom: 12px;
+    font-size: 15.2px;
+    line-height: 1.4;
   }
 
   .mobile-flow-footer__list .mobile-flow-footer__link {
@@ -2136,9 +2195,9 @@
   }
 
   .mobile-flow-footer__title {
-    margin-bottom: 9px;
-    font-size: 15px;
-    line-height: 1.46;
+    margin-bottom: 10px;
+    font-size: 14.7px;
+    line-height: 1.42;
   }
 
   .mobile-flow-footer__list .mobile-flow-footer__link {
@@ -2324,7 +2383,9 @@
   }
 
   .mobile-flow-footer__title {
-    font-size: 14.5px;
+    margin-bottom: 9px;
+    font-size: 14.15px;
+    line-height: 1.42;
   }
 
   .mobile-flow-footer__list .mobile-flow-footer__link {
@@ -2416,8 +2477,8 @@
 /* 350px 이하 */
 @media screen and (max-width: 350px) {
   header .header-nav {
-    padding: 18px 12px calc(66px + env(safe-area-inset-bottom, 0px));
-    scroll-padding-bottom: calc(66px + env(safe-area-inset-bottom, 0px));
+    padding: 18px 12px 0;
+    scroll-padding-bottom: calc(92px + env(safe-area-inset-bottom, 0px));
   }
 
   header .header-nav__top {
@@ -2425,15 +2486,26 @@
     padding-bottom: 14px;
   }
 
-  header .header-close--floating {
-    right: auto;
-    bottom: calc(2px + env(safe-area-inset-bottom, 0px));
-    width: 42px;
-    height: 42px;
+  header .header-nav__actions {
+    gap: 8px;
+    margin: 8px -12px 0;
+    padding: 16px 12px calc(14px + env(safe-area-inset-bottom, 0px));
+  }
+
+  header .header-nav__close-action {
+    width: min(100%, 280px);
+    min-height: 44px;
+    padding: 0 16px;
+    font-size: 12.5px;
+    border-radius: 11px;
   }
 
   header .main-menu {
     padding-top: 14px;
+  }
+
+  header.is-nav-actions-visible .main-menu {
+    padding-bottom: 14px;
   }
 
   header .main-menu .item > .item__name {
@@ -2594,7 +2666,9 @@
   }
 
   .mobile-flow-footer__title {
-    font-size: 13.5px;
+    margin-bottom: 8px;
+    font-size: 13.2px;
+    line-height: 1.4;
   }
 
   .mobile-flow-footer__list .mobile-flow-footer__link {

--- a/css/app.css
+++ b/css/app.css
@@ -45,6 +45,14 @@
    - 여기서는 데스크탑에서 모바일 CTA가 노출되지 않도록 보강
 ========================================================= */
 
+@media screen and (min-width: 950px) {
+  .footer a:hover {
+    text-decoration: underline;
+    text-decoration-color: currentColor;
+    text-underline-offset: 2px;
+  }
+}
+
 /* =========================================================
    태블릿 ~ 모바일 시작 | 950px 이하
    - Hero는 대표 음료 1개만
@@ -83,6 +91,35 @@
     position: static;
     display: inline-block;
     margin: 20px 0;
+  }
+}
+
+@media screen and (max-width: 959px) {
+  #footer {
+    padding: 34px 0 calc(28px + env(safe-area-inset-bottom, 0px));
+  }
+
+  .footer-desktop {
+    display: none;
+  }
+
+  .mobile-flow-footer {
+    display: block;
+  }
+}
+
+@media screen and (min-width: 541px) and (max-width: 959px) {
+  .mobile-flow-footer__inner {
+    max-width: 700px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    column-gap: 36px;
+    row-gap: 0;
+  }
+
+  .mobile-flow-footer__policy,
+  .mobile-flow-footer__info,
+  .mobile-flow-footer__copyright {
+    grid-column: 1 / -1;
   }
 }
 
@@ -1460,6 +1497,17 @@
   }
 }
 
+/* 949px 이하 */
+@media screen and (max-width: 949px) {
+  .footer a:focus,
+  .footer a:focus-visible,
+  .footer a:active {
+    text-decoration: underline;
+    text-decoration-color: currentColor;
+    text-underline-offset: 2px;
+  }
+}
+
 /* 899px 이하 */
 @media screen and (max-width: 899px) {
   .visual {
@@ -1753,6 +1801,27 @@
   .mobile-flow__promo-card {
     grid-template-columns: 74px minmax(0, 1fr);
     border-radius: 20px;
+  }
+
+  .mobile-flow-footer__inner {
+    padding: 0 16px;
+  }
+
+  .mobile-flow-footer__section {
+    padding: 20px 0 16px;
+  }
+
+  .mobile-flow-footer__title {
+    font-size: 15.5px;
+  }
+
+  .mobile-flow-footer__list .mobile-flow-footer__link {
+    font-size: 13px;
+  }
+
+  .mobile-flow-footer__info {
+    font-size: 11.6px;
+    line-height: 1.7;
   }
 }
 
@@ -2053,6 +2122,51 @@
   .mobile-flow__notice-link {
     gap: 8px;
   }
+
+  #footer {
+    padding: 30px 0 calc(24px + env(safe-area-inset-bottom, 0px));
+  }
+
+  .mobile-flow-footer__inner {
+    padding: 0 14px;
+  }
+
+  .mobile-flow-footer__section {
+    padding: 18px 0 15px;
+  }
+
+  .mobile-flow-footer__title {
+    margin-bottom: 9px;
+    font-size: 15px;
+    line-height: 1.46;
+  }
+
+  .mobile-flow-footer__list .mobile-flow-footer__link {
+    font-size: 12.75px;
+    line-height: 1.56;
+  }
+
+  .mobile-flow-footer__policy {
+    gap: 5px 12px;
+    padding-top: 15px;
+  }
+
+  .mobile-flow-footer__policy .mobile-flow-footer__link {
+    font-size: 11px;
+  }
+
+  .mobile-flow-footer__info {
+    margin-top: 12px;
+    font-size: 11.4px;
+    line-height: 1.68;
+  }
+
+  .mobile-flow-footer__copyright {
+    padding-top: 10px;
+    font-size: 10.55px;
+    line-height: 1.6;
+    letter-spacing: 0.026em;
+  }
 }
 
 /* 390px 이하 */
@@ -2199,6 +2313,42 @@
 
   .mobile-flow__notice-text {
     font-size: 11.5px;
+  }
+
+  .mobile-flow-footer__inner {
+    padding: 0 12px;
+  }
+
+  .mobile-flow-footer__section {
+    padding: 17px 0 14px;
+  }
+
+  .mobile-flow-footer__title {
+    font-size: 14.5px;
+  }
+
+  .mobile-flow-footer__list .mobile-flow-footer__link {
+    font-size: 12.5px;
+    line-height: 1.58;
+  }
+
+  .mobile-flow-footer__policy {
+    gap: 5px 10px;
+  }
+
+  .mobile-flow-footer__policy .mobile-flow-footer__link {
+    font-size: 10.75px;
+  }
+
+  .mobile-flow-footer__info {
+    font-size: 11px;
+    line-height: 1.64;
+  }
+
+  .mobile-flow-footer__copyright {
+    font-size: 10.3px;
+    line-height: 1.58;
+    letter-spacing: 0.024em;
   }
 }
 
@@ -2433,5 +2583,37 @@
 
   .whats-new__pagination {
     padding: 5px 9px;
+  }
+
+  #footer {
+    padding: 28px 0 calc(22px + env(safe-area-inset-bottom, 0px));
+  }
+
+  .mobile-flow-footer__inner {
+    padding: 0 10px;
+  }
+
+  .mobile-flow-footer__title {
+    font-size: 13.5px;
+  }
+
+  .mobile-flow-footer__list .mobile-flow-footer__link {
+    font-size: 11.75px;
+    line-height: 1.54;
+  }
+
+  .mobile-flow-footer__policy .mobile-flow-footer__link {
+    font-size: 10.5px;
+  }
+
+  .mobile-flow-footer__info {
+    font-size: 10.8px;
+    line-height: 1.62;
+  }
+
+  .mobile-flow-footer__copyright {
+    font-size: 10.1px;
+    line-height: 1.56;
+    letter-spacing: 0.022em;
   }
 }

--- a/css/common.css
+++ b/css/common.css
@@ -25,12 +25,6 @@ a {
   text-decoration: none;
 }
 
-a:hover,
-a:focus {
-  text-decoration: underline;
-  text-underline-position: under;
-  text-underline-offset: 2px;
-}
 
 strong {
   font-size: 100%;

--- a/css/signin.css
+++ b/css/signin.css
@@ -12,7 +12,7 @@
     background-attachment: fixed;
 }
 
-h2 {
+#signin > h2 {
     color: #fefefe;
     font-size: 30px;
     font-weight: normal;

--- a/css/style.css
+++ b/css/style.css
@@ -1469,154 +1469,355 @@ body.order-choice-open {
   z-index: 4;
 }
 
-/* footer */
+/* =========================================================
+   Footer Base
+   - style.css: footer 공통/desktop/mobile 기본 형태
+   - app.css: breakpoint별 전환과 반응형 보정
+========================================================= */
 
+/* Footer: shared shell */
 #footer {
-  background: #2c2a29;
+  --footer-bg-top: #2f2b29;
+  --footer-bg-bottom: #23201e;
+  --footer-text: #fff;
+  --footer-link: #f1ebe4;
+  --footer-link-muted: #ddd4cb;
+  --footer-muted: rgba(255, 255, 255, 0.6);
+  --footer-muted-soft: rgba(255, 255, 255, 0.46);
+  --footer-border: rgba(255, 255, 255, 0.11);
+  --footer-border-soft: rgba(255, 255, 255, 0.07);
+  --footer-surface: rgba(255, 255, 255, 0.05);
+  --footer-surface-strong: rgba(255, 255, 255, 0.07);
+  --footer-accent: #00a862;
+  --footer-shadow: 0 18px 32px rgba(0, 0, 0, 0.16);
   position: relative;
   display: block;
   width: 100%;
-  padding: 32px 0 35px 0;
+  padding: 40px 0 36px;
   clear: both;
+  background: linear-gradient(180deg, var(--footer-bg-top) 0%, var(--footer-bg-bottom) 100%);
 }
- .footer_wrap {
-  background: url('../images/footer_logo.png') right 8px no-repeat;
-  width: 1200px;
-  display: inline-block;
-  position: relative;
-  left: 50%;
-  margin-left: -591px;
+
+.footer {
+  color: var(--footer-text);
 }
- .footer_menus {
-  display: flex;
-  justify-content: center;
+
+/* Footer: shared link interaction base */
+.footer a {
+  text-decoration: none;
+  transition:
+    color 0.18s ease,
+    border-color 0.18s ease,
+    text-decoration-color 0.18s ease,
+    opacity 0.24s ease;
 }
- .footer_menus ul {
-  display: inline-block;
-  vertical-align: top;
-  margin-bottom: 20px;
-  width: 220px;
+
+.footer a:hover {
+  opacity: 1;
+  text-decoration: none;
 }
- .footer_menus ul li {
-  line-height: 1.4;
-  padding: 0 10px;
-  letter-spacing: -1px;
+
+.footer a:focus-visible {
+  outline: 2px solid rgba(0, 168, 98, 0.9);
+  outline-offset: 3px;
+  border-radius: 10px;
 }
- .footer_menus ul li:first-child {
-  color: #fff;
-  margin-bottom: 6px;
-  text-transform: uppercase;
-}
- .footer_menus ul li:first-child a {
-  font-weight: normal;
-  font-size: 14px;
-}
- .footer_menus ul li a {
-  color: #fff;
-  font-size: 12px;
-  font-weight: 500;
-  line-height: 24px;
-  color: #fff;
-  cursor: default;
-}
- .footer_menus ul li a:hover {
-  cursor: pointer;
-}
- .footer_awards_wrap {
-  background: #282828;
-  position: relative;
-  width: 100%;
-  padding-top: 20px;
-  height: 80px;
-  margin-top: 40px;
-}
-.footer_award_inner {
-  position: absolute;
-  left: 50%;
-  margin-left: -591px;
-  width: 100%;
-  padding-bottom: 20px;
-}
-.footer_award_list {
-  display: inline-block;
-  position: relative;
-}
-.footer_award_list li {
-  float: left;
-  position: relative;
-  cursor: pointer;
-}
-.footer_award_list li a {  
+
+/* Footer: desktop base */
+.footer-desktop {
   display: block;
 }
-.award_list img {
+
+.footer-desktop__inner {
+  max-width: 1200px;
   margin: 0 auto;
+  padding: 0 24px;
 }
-.footer_util,
-.footer_util a { 
-  color:#999;
+
+.footer-desktop__top {
+  padding-bottom: 8px;
 }
-.footer_util { 
-  left:50%; 
-  position:relative;
-  color:#999; 
-  font-size:12px; 
-  line-height:18px;
-  margin-left:-50%; 
-  padding-top:30px; 
-  text-align:center; 
-  width:100%; 
+
+.footer-desktop__menu {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 28px 24px;
+  justify-content: space-between;
 }
-.footer_util a {
-  display:inline-block; 
-  border-right:1px solid #393939; 
-  color:#ccc;
-  font-size:12px; 
-  padding:0 10px;
-} 
-.footer_util a:hover {
-  text-decoration: underline;
+
+.footer-desktop__menu-group {
+  flex: 1 1 180px;
+  min-width: 160px;
 }
-.footer_util > a.last-child { 
-  border:0; 
+
+.footer-desktop__menu-title {
+  margin: 0 0 10px;
+  color: var(--footer-text);
+  font-size: 14px;
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
-.footer_util a.btned_link { 
-  background:none; 
-  border:2px solid #fff; 
-  border-radius:3px; 
-  color:#fff; 
-  display:inline-block; 
-  font-size:12px; 
-  margin:10px 2px 0 3px; 
-  width:90px; 
-  height:30px; 
-  line-height:30px; 
+
+.footer-desktop__menu-list {
+  margin: 0;
+  padding: 0;
 }
-.footer_util span.end { 
-  display:inline-block; 
-  line-height:40px; 
+
+.footer-desktop__menu-item + .footer-desktop__menu-item {
+  margin-top: 4px;
 }
-.footer_util ul.copy_menu { 
-  padding: 25px 0 5px 0; 
-  margin: 0 auto; 
+
+.footer-desktop__menu-link {
+  color: var(--footer-link);
+  font-size: 12px;
+  line-height: 1.8;
+}
+
+.footer-desktop__awards {
+  margin-top: 36px;
+  padding: 20px 0;
+  border-top: 1px solid var(--footer-border-soft);
+  border-bottom: 1px solid var(--footer-border-soft);
+}
+
+.footer-desktop__awards ul {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px 18px;
+}
+
+.footer-desktop__awards a {
+  display: block;
+}
+
+.footer-desktop__awards img {
+  display: block;
+  height: auto;
+  max-width: 100%;
+}
+
+.footer-desktop__bottom {
+  padding-top: 28px;
   text-align: center;
 }
-.footer_util ul.copy_menu li {
-  line-height: 1.3; 
-  display: inline-block; 
-  margin: 0 7px; 
+
+.footer-desktop__policy {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px 0;
 }
-.footer_util > :first-child , 
-.footer_util > :nth-child(4) { 
-  color: #00b050 ; 
-  font-weight: bold; 
+
+.footer-desktop__policy a {
+  padding: 0 12px;
+  border-right: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--footer-link-muted);
+  font-size: 12px;
+  line-height: 1.5;
 }
-.footer_util li a::before {
-  display: block;
-  content: "";
-  float: left;
-  width: 1px;
-  height: 11px;
+
+.footer-desktop__policy a:last-child {
+  border-right: 0;
+}
+
+.footer-desktop__policy a:first-child,
+.footer-desktop__policy a:nth-child(4) {
+  color: var(--footer-accent);
+  font-weight: 700;
+}
+
+.footer-desktop__policy a:first-child {
+  color: #00b050;
+}
+
+.footer-desktop__buttons {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 18px;
+}
+
+.footer-desktop__buttons a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 92px;
+  min-height: 32px;
+  padding: 0 12px;
+  border: 1px solid rgba(255, 255, 255, 0.72);
+  border-radius: 3px;
+  color: var(--footer-text);
+  font-size: 12px;
+}
+
+.footer-desktop__info {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 7px 16px;
+  margin-top: 20px;
+  color: rgba(255, 255, 255, 0.64);
+  font-size: 12.25px;
+  font-weight: 400;
+  line-height: 1.68;
+  letter-spacing: 0.006em;
+}
+
+/* Footer: shared meta text */
+.footer-desktop__info,
+.mobile-flow-footer__info,
+.footer-desktop__copyright,
+.mobile-flow-footer__copyright {
+  font-family: "Noto Sans KR", "Apple SD Gothic Neo", "Malgun Gothic", sans-serif;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  font-variant-numeric: tabular-nums;
+}
+
+.footer-desktop__info p,
+.mobile-flow-footer__info p {
+  margin: 0;
+}
+
+.footer-desktop__copyright,
+.mobile-flow-footer__copyright {
   margin: 11px 0 0;
-  background-color: #515154;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 11.15px;
+  font-weight: 500;
+  line-height: 1.62;
+  letter-spacing: 0.03em;
+}
+
+/* Footer: mobile base */
+.mobile-flow-footer {
+  display: none;
+}
+
+.mobile-flow-footer__inner {
+  width: 100%;
+  max-width: 560px;
+  margin: 0 auto;
+  padding: 0 18px;
+  display: grid;
+  gap: 0;
+}
+
+.mobile-flow-footer__section {
+  position: relative;
+  overflow: visible;
+  padding: 22px 0 18px;
+  border-top: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 0;
+  background: none;
+  box-shadow: none;
+}
+
+.mobile-flow-footer__section::after {
+  display: none;
+  content: "";
+}
+
+
+.mobile-flow-footer__title {
+  margin: 0 0 11px;
+  padding-left: 0;
+  color: rgba(255, 255, 255, 0.96);
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1.48;
+  letter-spacing: -0.025em;
+  text-wrap: balance;
+}
+
+.mobile-flow-footer__title::before {
+  display: none;
+  content: "";
+}
+
+.mobile-flow-footer__list {
+  display: grid;
+  gap: 0;
+}
+
+.mobile-flow-footer__item + .mobile-flow-footer__item {
+  margin-top: 1px;
+}
+
+.mobile-flow-footer__link {
+  display: inline-block;
+  color: var(--footer-link-muted);
+  font-size: 13.5px;
+  line-height: 1.58;
+  letter-spacing: -0.01em;
+  word-break: keep-all;
+  overflow-wrap: anywhere;
+}
+
+.mobile-flow-footer__list .mobile-flow-footer__link {
+  display: block;
+  width: auto;
+  padding: 4px 0;
+  color: rgba(241, 235, 228, 0.94);
+  font-size: 13.5px;
+  font-weight: 500;
+  line-height: 1.62;
+}
+
+.mobile-flow-footer__list .mobile-flow-footer__link::after {
+  content: none;
+}
+
+.mobile-flow-footer__policy {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 14px;
+  margin-top: 2px;
+  padding-top: 16px;
+  border-top: 1px solid var(--footer-border-soft);
+}
+
+.mobile-flow-footer__policy .mobile-flow-footer__link {
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: none;
+  color: rgba(255, 255, 255, 0.64);
+  font-size: 11.5px;
+  font-weight: 500;
+  line-height: 1.6;
+  white-space: nowrap;
+}
+
+.mobile-flow-footer__policy .mobile-flow-footer__link:first-child {
+  color: #00b050;
+  font-weight: 700;
+}
+
+.mobile-flow-footer__info {
+  display: grid;
+  gap: 4px;
+  margin-top: 13px;
+  padding-top: 0;
+  color: rgba(255, 255, 255, 0.62);
+  font-size: 11.95px;
+  font-weight: 400;
+  line-height: 1.72;
+  letter-spacing: 0.005em;
+  word-break: keep-all;
+  overflow-wrap: anywhere;
+}
+
+.mobile-flow-footer__copyright {
+  margin: 0;
+  padding-top: 13px;
+  color: rgba(255, 255, 255, 0.47);
+  font-size: 11px;
+  line-height: 1.6;
+  letter-spacing: 0.028em;
+  word-break: keep-all;
+  overflow-wrap: anywhere;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -1551,12 +1551,23 @@ body.order-choice-open {
 }
 
 .footer-desktop__menu-title {
-  margin: 0 0 10px;
-  color: var(--footer-text);
-  font-size: 14px;
-  font-weight: 400;
+  margin: 0 0 12px;
+  color: rgba(255, 255, 255, 0.92);
+  font-family: "Nanum Gothic", "Noto Sans KR", "Apple SD Gothic Neo", "Malgun Gothic", sans-serif;
+  font-size: 12.75px;
+  font-weight: 700;
+  line-height: 1.46;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.085em;
+}
+
+.footer-desktop__menu-title::after {
+  content: "";
+  display: block;
+  width: 18px;
+  height: 1px;
+  margin-top: 8px;
+  background: linear-gradient(90deg, rgba(0, 168, 98, 0.72), rgba(0, 168, 98, 0));
 }
 
 .footer-desktop__menu-list {
@@ -1682,6 +1693,17 @@ body.order-choice-open {
   margin: 0;
 }
 
+.footer-desktop__info a[x-apple-data-detectors],
+.mobile-flow-footer__info a[x-apple-data-detectors],
+.footer-desktop__copyright a[x-apple-data-detectors],
+.mobile-flow-footer__copyright a[x-apple-data-detectors] {
+  color: inherit !important;
+  font: inherit !important;
+  letter-spacing: inherit !important;
+  line-height: inherit !important;
+  text-decoration: none !important;
+}
+
 .footer-desktop__copyright,
 .mobile-flow-footer__copyright {
   margin: 11px 0 0;
@@ -1709,8 +1731,8 @@ body.order-choice-open {
 .mobile-flow-footer__section {
   position: relative;
   overflow: visible;
-  padding: 22px 0 18px;
-  border-top: 1px solid rgba(255, 255, 255, 0.09);
+  padding: 23px 0 19px;
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
   border-radius: 0;
   background: none;
   box-shadow: none;
@@ -1723,13 +1745,16 @@ body.order-choice-open {
 
 
 .mobile-flow-footer__title {
-  margin: 0 0 11px;
+  display: block;
+  margin: 0 0 15px;
   padding-left: 0;
-  color: rgba(255, 255, 255, 0.96);
-  font-size: 16px;
+  color: rgba(255, 255, 255, 0.985);
+  font-family: "Nanum Gothic", "Noto Sans KR", "Apple SD Gothic Neo", "Malgun Gothic", sans-serif;
+  font-size: 15.9px;
   font-weight: 700;
-  line-height: 1.48;
-  letter-spacing: -0.025em;
+  line-height: 1.4;
+  letter-spacing: -0.03em;
+  word-break: keep-all;
   text-wrap: balance;
 }
 
@@ -1761,10 +1786,10 @@ body.order-choice-open {
   display: block;
   width: auto;
   padding: 4px 0;
-  color: rgba(241, 235, 228, 0.94);
+  color: rgba(241, 235, 228, 0.9);
   font-size: 13.5px;
   font-weight: 500;
-  line-height: 1.62;
+  line-height: 1.64;
 }
 
 .mobile-flow-footer__list .mobile-flow-footer__link::after {

--- a/docs/2026-04-12.md
+++ b/docs/2026-04-12.md
@@ -1,0 +1,125 @@
+# 2026-04-12 작업 기록
+
+## 개요
+
+스타벅스 리뉴얼 프로젝트의 footer를 기준으로  
+데스크탑/모바일 구조 분리, naming foundation 정리, 모바일 중심 UI polish, 반응형 인터랙션 규칙 정리까지 진행했다.
+
+이번 기록은 `footer renewal` 범위까지만 정리한 문서이며,  
+이후 예정인 `nav-open` 상태의 하단 로직 수정은 다음 커밋 범위로 분리하는 것을 전제로 작성한다.
+
+---
+
+## 작업 요약
+
+| 구분 | 내용 |
+| --- | --- |
+| Footer foundation | 데스크탑/모바일 footer HTML 구조를 완전히 분리하고 class naming 규칙을 통일 |
+| Desktop structure 정리 | 공홈 유사 정보 구조를 유지하면서 `footer-desktop` 체계로 재구성 |
+| Mobile structure 정리 | `mobile-flow-footer` 기준으로 모바일 전용 정보 흐름을 별도 구성 |
+| Mobile UI polish | 카드형 느낌을 줄이고 브랜드 무드에 맞는 spacing, divider, typography로 재조정 |
+| Footer interaction 정리 | 데스크탑은 hover, 모바일/태블릿은 focus/active 중심으로 링크 상태 규칙 분리 |
+| CSS 역할 정리 | footer 기본 스타일은 `style.css`, 반응형 오버라이드는 `app.css`로 재정리 |
+| Typography refinement | 사업자 정보 / copyright 메타 타이포를 더 차분하고 정돈된 방향으로 보정 |
+| 문서화 | 오늘 작업 범위를 `docs/2026-04-12.md`로 기록 |
+
+---
+
+## 주요 작업 상세
+
+### 1. footer HTML foundation 분리
+- footer 내부를 `footer-desktop`과 `mobile-flow-footer` 두 블록으로 명확히 분리했다.
+- 데스크탑 footer는 기존 스타벅스 공홈과 유사한 메뉴 그룹, 정책 링크, 버튼, 사업자 정보 흐름을 유지했다.
+- 모바일 footer는 모바일 사용자의 마지막 안내 영역이라는 기준으로 별도 정보 블록 구조를 만들었다.
+- 같은 footer 구조가 필요한 페이지에도 동일하게 반영하기 위해 `index.html`, `signup/index.html` 양쪽에 구조를 맞췄다.
+
+### 2. class naming / 정보 구조 정리
+- 데스크탑은 `footer-desktop__*`, 모바일은 `mobile-flow-footer__*` 체계로 naming을 통일했다.
+- `footer-mobile`, `mobile-footer` 같은 혼용 네이밍 없이 구조만 봐도 용도가 드러나도록 정리했다.
+- 모바일 정보 구조는 아래 4개 흐름을 유지하도록 정리했다.
+- `스타벅스를 이용해보세요`
+- `메뉴와 커피를 더 알고 싶다면`
+- `스타벅스가 궁금하다면`
+- `더 필요한 안내`
+
+### 3. mobile footer UI 톤 재조정
+- 처음의 카드형 메뉴 묶음 느낌을 줄이고, footer다운 리듬과 간격 중심으로 다시 정리했다.
+- 과한 box, radius, shadow, arrow 중심 표현은 걷어내고 section rhythm과 얇은 divider로 구분했다.
+- 링크는 앱 메뉴처럼 보이지 않게 정보성 footer 링크 톤으로 다시 맞췄다.
+- 정책/사업자 정보/copyright 흐름이 본문 링크 리스트와 다르게 읽히도록 하단 위계를 분리했다.
+
+### 4. 반응형 및 링크 인터랙션 정리
+- `950px 이상`에서는 footer 내부 링크 hover 시 underline이 보이도록 정리했다.
+- `949px 이하`에서는 hover 의존성을 줄이고 `focus / focus-visible / active` 상태에서만 underline이 보이도록 분리했다.
+- 초소형 모바일 구간까지 고려해 `959 / 899 / 767 / 540 / 390 / 350px` 기준으로 footer 간격과 타이포를 단계적으로 조정했다.
+- 데스크탑과 모바일 footer 전환, 2열 레이아웃, 메타 정보 밀도 조정은 모두 반응형 구간에 맞춰 오버라이드되도록 분리했다.
+
+### 5. CSS 파일 역할 재정리
+- footer의 기본 형태와 공통 스타일은 `style.css`에 남겼다.
+- footer의 반응형 전환과 breakpoint별 보정은 `app.css`로 이동해 파일 역할을 다시 분명히 했다.
+- `style.css` 안 footer 구간도 `shared / desktop / mobile` 기준으로 주석과 블록을 정리해 유지보수 진입점을 명확히 했다.
+
+### 6. footer 하단 메타 타이포 보정
+- 사업자 정보와 copyright 텍스트가 작은 시스템 문구처럼 흐릿하게 보이던 부분을 다시 손봤다.
+- 메타 텍스트는 더 차분하고 정돈된 인상으로 보이도록 `font-size`, `font-weight`, `line-height`, `letter-spacing`, 색 대비를 재조정했다.
+- 정보 텍스트와 copyright 간 위계를 분리해, 조용하지만 뭉개지지 않는 footer 타이포를 목표로 보정했다.
+
+### 7. footer 스크립트 최소 보정
+- footer 자체 interaction JS는 아직 추가하지 않았다.
+- 다만 footer 내부 연도 표기가 여러 곳에서 함께 갱신될 수 있도록 `js/common.js`의 연도 처리 로직만 `querySelectorAll` 기준으로 보정했다.
+- 추후 모바일 아코디언 등 확장이 필요할 때 붙이기 쉬운 구조는 유지한 상태다.
+
+---
+
+## 작업 중 발생한 이슈
+
+| 이슈 | 내용 | 대응 |
+| --- | --- | --- |
+| 모바일 footer가 카드형 메뉴처럼 보임 | footer보다 범용 앱 UI처럼 읽히는 인상이 강했음 | box/shadow 중심 표현을 줄이고 section rhythm 위주로 재정리 |
+| hover 반응이 과하게 밝음 | 링크 hover가 네온사인처럼 튀어 보였음 | footer 링크 상태 규칙을 다시 정리하고 반응형 기준으로 분리 |
+| 반응형 footer 규칙 위치 혼재 | footer responsive CSS가 `style.css`에 섞여 있어 역할 구분이 흐려짐 | 기본은 `style.css`, 반응형은 `app.css`로 이동 |
+| 하단 메타 텍스트가 시스템 기본 문구처럼 보임 | 정보 텍스트와 copyright가 흐리고 둥글게 보여 브랜드 무드가 약했음 | 메타 타이포 weight, spacing, contrast를 재보정 |
+
+---
+
+## 현재 수정 파일
+
+- `index.html`
+- `signup/index.html`
+- `css/common.css`
+- `css/style.css`
+- `css/app.css`
+- `js/common.js`
+
+---
+
+## 현재 추가 파일
+
+- `docs/2026-04-12.md`
+
+---
+
+## 현재 상태
+
+- footer는 데스크탑/모바일 구조가 분리된 상태로 foundation과 1차 UI 정리가 끝난 상태다.
+- 모바일 footer는 사용자 중심 정보 구조와 브랜드 무드에 맞춘 하단 안내 영역 톤으로 한 차례 정리되었다.
+- 반응형 전환 규칙과 링크 인터랙션 규칙도 footer 범위 기준으로 정리된 상태다.
+- 하단 메타 타이포 역시 이전보다 또렷하고 정돈된 방향으로 보정되었다.
+
+---
+
+## 커밋 분리 메모
+
+- 이번 문서는 `footer renewal` 범위 커밋을 기준으로 작성했다.
+- 다음 작업 예정인 `nav-open` 상태의 하단 로직 수정은 이번 범위에 포함하지 않는다.
+- 커밋을 분리할 때는 footer 관련 변경을 먼저 정리하고, 이후 `nav-open` 하단 로직은 별도 커밋으로 분리하는 것이 좋다.
+- 특히 `css/app.css`처럼 footer 반응형 규칙과 다른 모바일 로직이 같이 존재하는 파일은 hunk 기준으로 나눠 커밋하는 편이 안전하다.
+
+---
+
+## 다음 작업 후보
+
+- `nav-open` 상태에서의 하단 로직 수정
+- footer 실제 디바이스 기준 시각 QA
+- 필요 시 모바일 footer 아코디언 interaction 설계
+

--- a/docs/2026-04-12.md
+++ b/docs/2026-04-12.md
@@ -5,8 +5,8 @@
 스타벅스 리뉴얼 프로젝트의 footer를 기준으로  
 데스크탑/모바일 구조 분리, naming foundation 정리, 모바일 중심 UI polish, 반응형 인터랙션 규칙 정리까지 진행했다.
 
-이번 기록은 `footer renewal` 범위까지만 정리한 문서이며,  
-이후 예정인 `nav-open` 상태의 하단 로직 수정은 다음 커밋 범위로 분리하는 것을 전제로 작성한다.
+이후 같은 흐름에서 모바일 `nav-open` 상태의 하단 액션 UX도 함께 정리했고,  
+footer의 Safari 자동 감지 이슈 대응과 footer title 추가 polish까지 이어서 반영했다.
 
 ---
 
@@ -21,6 +21,8 @@
 | Footer interaction 정리 | 데스크탑은 hover, 모바일/태블릿은 focus/active 중심으로 링크 상태 규칙 분리 |
 | CSS 역할 정리 | footer 기본 스타일은 `style.css`, 반응형 오버라이드는 `app.css`로 재정리 |
 | Typography refinement | 사업자 정보 / copyright 메타 타이포를 더 차분하고 정돈된 방향으로 보정 |
+| Footer 추가 polish | Safari 자동 감지 대응, footer title 위계/spacing 재보정 |
+| Mobile nav action 정리 | 하단 floating close를 걷고 sticky close action 영역 기준으로 모바일 nav UX를 재설계 |
 | 문서화 | 오늘 작업 범위를 `docs/2026-04-12.md`로 기록 |
 
 ---
@@ -69,6 +71,23 @@
 - 다만 footer 내부 연도 표기가 여러 곳에서 함께 갱신될 수 있도록 `js/common.js`의 연도 처리 로직만 `querySelectorAll` 기준으로 보정했다.
 - 추후 모바일 아코디언 등 확장이 필요할 때 붙이기 쉬운 구조는 유지한 상태다.
 
+### 8. footer 후속 polish / Safari 대응
+- footer 하단 사업자 정보와 copyright 영역에서 Safari가 전화번호/숫자 포맷을 자동 링크로 감지해 파란색으로 보이던 이슈를 확인했다.
+- 이 부분은 `meta format-detection`과 `x-apple-data-detectors` 대응 CSS를 함께 적용해 footer 텍스트 톤이 강제로 깨지지 않도록 정리했다.
+- 이 작업은 브라우저 자동 감지가 실제 디자인 톤을 깨뜨릴 수 있다는 점을 배운 사례로 남겨둘 만한 포인트였다.
+- 모바일 footer title은 포인트 바를 포함한 방향과 제거한 방향을 모두 비교해 보면서, 현재 프로젝트와 footer 톤에 더 맞는 쪽으로 title 위계/spacing을 재조정했다.
+- 결과적으로 footer title은 링크 목록보다 먼저 읽히도록 위계를 강화하고, 과한 장식보다는 읽기 쉬운 정보 구조 중심으로 정리했다.
+
+### 9. mobile nav 하단 액션 정리
+- 처음에는 `nav-open` 상태에서 하단 근처 도달 시 floating close 버튼이 보이도록 접근했지만, 모바일에서 콘텐츠 위를 덮거나 경계에서 흔들리는 문제가 있었다.
+- 이후 sentinel, observer, floating close 방식보다 현재 프로젝트에 더 설명 가능하고 유지보수하기 쉬운 방향으로 다시 정리했다.
+- nav 하단에는 sticky close action 구조를 두고, 상단 X 버튼과 별개로 사용자가 아래까지 읽었을 때 바로 닫을 수 있는 보조 액션 영역으로 설계했다.
+- 이 과정에서 하단 action 영역이 처음부터 무겁게 보이지 않도록, nav open 직후에는 숨기고 아코디언 메뉴 탐색이 시작된 뒤에만 나타나도록 제어했다.
+- nav쪽 모바일은 각각 브라우저의 실제 사용하고있는 하단 높이에 따라 아코디언이 실시간으로 개입하는 부분에 있어서 내가 의도햇던 바 보다 쉽게 현재 내 프로젝트에서 적용하기 쉽진 않았고 다시 수정방향을 잡아서 현재 프로젝트의 의도에 맞게 하단 고정 방식을 채택하여 open시 숨기고 아코디언이 펼쳐질 때 나타나게 하여 의도와 비슷하게 반영했다.
+- 결국 하단 액션은 `하단 도달 시 떠오르는 버튼`이 아니라 `탐색 이후에 나타나는 sticky close action`으로 정리했고, 현재 프로젝트의 모바일 흐름에는 이 방식이 더 자연스럽다고 판단했다.
+- 추가로 `signup/` 페이지의 모바일 header/nav 마크업도 루트 기준으로 맞추고, quick action / 통합검색 구조를 동일 기준으로 정리했다.
+- 루트 `main.js`에서는 존재하지 않는 요소를 대상으로 GSAP/Swiper/ScrollMagic이 동작하면서 발생하던 콘솔 경고를 요소 존재 여부 기준으로 가드 처리했다.
+
 ---
 
 ## 작업 중 발생한 이슈
@@ -79,6 +98,10 @@
 | hover 반응이 과하게 밝음 | 링크 hover가 네온사인처럼 튀어 보였음 | footer 링크 상태 규칙을 다시 정리하고 반응형 기준으로 분리 |
 | 반응형 footer 규칙 위치 혼재 | footer responsive CSS가 `style.css`에 섞여 있어 역할 구분이 흐려짐 | 기본은 `style.css`, 반응형은 `app.css`로 이동 |
 | 하단 메타 텍스트가 시스템 기본 문구처럼 보임 | 정보 텍스트와 copyright가 흐리고 둥글게 보여 브랜드 무드가 약했음 | 메타 타이포 weight, spacing, contrast를 재보정 |
+| Safari 자동 감지로 footer 텍스트 색이 깨짐 | 사업자등록번호 / TEL이 Safari에서 파란 링크처럼 보였음 | `format-detection` 메타와 `x-apple-data-detectors` CSS로 강제 보정 |
+| 모바일 nav 하단 close UX가 불안정함 | floating close / 하단 도달 감지 방식이 모바일 브라우저 실제 높이와 스크롤 맥락에서 흔들렸음 | sticky close action + 탐색 시작 이후 노출 방식으로 재설계 |
+| signup 페이지 nav 구조 불일치 | 루트와 다른 header/nav 구조 때문에 quick action과 통합검색이 어색하게 보였음 | `signup/index.html` nav 마크업을 루트 기준으로 동기화 |
+| 메인 스크립트 콘솔 경고 발생 | 없는 DOM에도 GSAP/Swiper/ScrollMagic 초기화가 시도됨 | selector 존재 여부를 확인하는 guard 로직 추가 |
 
 ---
 
@@ -90,6 +113,8 @@
 - `css/style.css`
 - `css/app.css`
 - `js/common.js`
+- `js/main.js`
+- `css/signin.css`
 
 ---
 
@@ -105,21 +130,24 @@
 - 모바일 footer는 사용자 중심 정보 구조와 브랜드 무드에 맞춘 하단 안내 영역 톤으로 한 차례 정리되었다.
 - 반응형 전환 규칙과 링크 인터랙션 규칙도 footer 범위 기준으로 정리된 상태다.
 - 하단 메타 타이포 역시 이전보다 또렷하고 정돈된 방향으로 보정되었다.
+- Safari 자동 감지로 인해 footer 텍스트 색이 깨지는 문제까지 대응해 footer 메타 영역 안정성이 올라간 상태다.
+- 모바일 nav는 하단 floating close 방식 대신 sticky close action 기준으로 다시 정리되었고, 아코디언 탐색 시작 이후에만 나타나는 보조 액션 UX로 정돈된 상태다
+- `signup/` 페이지의 모바일 nav도 루트 기준 구조와 동일한 흐름으로 맞춰진 상태다.
 
 ---
 
 ## 커밋 분리 메모
 
-- 이번 문서는 `footer renewal` 범위 커밋을 기준으로 작성했다.
-- 다음 작업 예정인 `nav-open` 상태의 하단 로직 수정은 이번 범위에 포함하지 않는다.
-- 커밋을 분리할 때는 footer 관련 변경을 먼저 정리하고, 이후 `nav-open` 하단 로직은 별도 커밋으로 분리하는 것이 좋다.
-- 특히 `css/app.css`처럼 footer 반응형 규칙과 다른 모바일 로직이 같이 존재하는 파일은 hunk 기준으로 나눠 커밋하는 편이 안전하다.
+- 이번 문서는 `footer renewal` 작업을 중심으로 하되, 이어서 진행된 mobile nav 하단 액션 정리까지 포함해 기록
+- 커밋을 분리할 때는 footer 구조/스타일, footer 후속 polish, mobile nav sticky action 정리 순으로 나눠 보는 것이 좋다
+- 특히 `css/app.css`처럼 footer 반응형 규칙과 nav 모바일 로직이 같이 존재하는 파일은 hunk 기준으로 나눠 커밋하는 편이 안전
+- Safari 자동 감지 대응처럼 학습 포인트가 있는 수정은 문서에 남겨두고, 커밋 메시지에서도 의도가 드러나게 분리하는 편이 좋음
 
 ---
 
 ## 다음 작업 후보
 
-- `nav-open` 상태에서의 하단 로직 수정
-- footer 실제 디바이스 기준 시각 QA
-- 필요 시 모바일 footer 아코디언 interaction 설계
-
+- 데스크탑에서 950px구간 반응형 마무리 (feature/responsive-core)
+- 반응형 안정화
+- 접근성 규칙을 활용하여 html 구조 재작성
+- 리소스 이미지 관리, 각 섹션 문단 배치 재정리

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="format-detection" content="telephone=no, date=no, address=no, email=no">
   <title>Starbucks Korea</title>
 
   <meta property="og:type" content="website" />
@@ -405,9 +406,9 @@
               </div>
             </li>
           </ul>
-          <button type="button" class="header-close header-close--floating" aria-label="전체 메뉴 닫기">
-            <span class="material-icons" aria-hidden="true">close</span>
-          </button>
+          <div class="header-nav__actions">
+            <button type="button" class="header-nav__close-action">메뉴 닫기</button>
+          </div>
           </div>
       </div>
       <div class="header-overlay"></div>

--- a/index.html
+++ b/index.html
@@ -1122,84 +1122,154 @@
     </div>
 
     <!-- 푸터 -->
-    <footer id="footer">
-
-      <div class="footer_wrap">
-        <div class="footer_menus" role="footerGroup" aria-labelledby="Group-label">
-          <ul class="first_menu">
-            <li><a href="javascript:void(0)" role="link">company</a></li>
-            <li><a href="javascript:void(0)">한눈에보기</a></li>
-            <li><a href="javascript:void(0)">스타벅스 사명</a></li>
-            <li><a href="javascript:void(0)">스타벅스 소개</a></li>
-            <li><a href="javascript:void(0)">컴플라이언스</a></li>
-            <li><a href="javascript:void(0)">국내 뉴스룸</a></li>
-            <li><a href="javascript:void(0)">세계의 스타벅스</a></li>
-            <li><a href="javascript:void(0)">글로벌 뉴스룸</a></li>
-          </ul>
-          <ul class="second_menu">
-            <li><a href="javascript:void(0)" role="link">corporate sales</a></li>
-            <li><a href="javascript:void(0)">단체 및 기업 구매 안내</a></li>
-            <li><a href="javascript:void(0)">단체 주문 배달 안내</a></li>
-          </ul>
-          <ul class="third_menu">
-            <li><a href="javascript:void(0)" role="link">partnership</a></li>
-            <li><a href="javascript:void(0)">신규 입점 제의</a></li>
-            <li><a href="javascript:void(0)">협력 고객사 등록신청</a></li>
-            <li><a href="javascript:void(0)">중개업체 확인</a></li>
-          </ul>
-          <ul class="fourth_menu">
-            <li><a href="javascript:void(0)" role="link">online community</a></li>
-            <li><a href="javascript:void(0)">페이스북</a></li>
-            <li><a href="javascript:void(0)">트위터</a></li>
-            <li><a href="javascript:void(0)">유튜브</a></li>
-            <li><a href="javascript:void(0)">인스타그램</a></li>
-          </ul>
-          <ul class="fifth_menu">
-            <li><a href="javascript:void(0)" role="link">recruit</a></li>
-            <li><a href="javascript:void(0)">채용 소개</a></li>
-            <li><a href="javascript:void(0)">채용 지원하기</a></li>
-          </ul>
+    <footer id="footer" class="footer">
+      <!-- Desktop footer -->
+      <div class="footer-desktop">
+        <div class="footer-desktop__inner">
+          <div class="footer-desktop__top">
+            <nav class="footer-desktop__menu" aria-label="스타벅스 데스크탑 푸터 메뉴">
+              <section class="footer-desktop__menu-group">
+                <h2 class="footer-desktop__menu-title">Company</h2>
+                <ul class="footer-desktop__menu-list">
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">한눈에 보기</a></li>
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">스타벅스 사명</a></li>
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">스타벅스 소개</a></li>
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">컴플라이언스</a></li>
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">국내 뉴스룸</a></li>
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">세계의 스타벅스</a></li>
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">글로벌 뉴스룸</a></li>
+                </ul>
+              </section>
+              <section class="footer-desktop__menu-group">
+                <h2 class="footer-desktop__menu-title">Corporate Sales</h2>
+                <ul class="footer-desktop__menu-list">
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">단체 및 기업 구매 안내</a></li>
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">단체 주문 배달 안내</a></li>
+                </ul>
+              </section>
+              <section class="footer-desktop__menu-group">
+                <h2 class="footer-desktop__menu-title">Partnership</h2>
+                <ul class="footer-desktop__menu-list">
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">신규 입점 제의</a></li>
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">협력 고객사 등록신청</a></li>
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">중개업체 확인</a></li>
+                </ul>
+              </section>
+              <section class="footer-desktop__menu-group">
+                <h2 class="footer-desktop__menu-title">Online Community</h2>
+                <ul class="footer-desktop__menu-list">
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">페이스북</a></li>
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">트위터</a></li>
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">유튜브</a></li>
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">인스타그램</a></li>
+                </ul>
+              </section>
+              <section class="footer-desktop__menu-group">
+                <h2 class="footer-desktop__menu-title">Recruit</h2>
+                <ul class="footer-desktop__menu-list">
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">채용 소개</a></li>
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">채용 지원하기</a></li>
+                </ul>
+              </section>
+            </nav>
+          </div>
+          <div class="footer-desktop__awards" aria-label="스타벅스 수상 내역">
+            <ul>
+              <li><a href="javascript:void(0)"><img src="./images/footer_award_image_01.jpg" alt="2020 여성가족부장관상"></a></li>
+              <li><a href="javascript:void(0)"><img src="./images/footer_award_image_02.jpg" alt="2020 행정안전부장관 표창"></a></li>
+              <li><a href="javascript:void(0)"><img src="./images/footer_award_image_03.jpg" alt="2020 농림축산식품부 장관상"></a></li>
+              <li><a href="javascript:void(0)"><img src="./images/footer_award_image_04.jpg" alt="2020 대한민국 중소중견기업혁신대상"></a></li>
+              <li><a href="javascript:void(0)"><img src="./images/footer_award_image_05.jpg" alt="2020 대한민국 일자리 유공 표창"></a></li>
+              <li><a href="javascript:void(0)"><img src="./images/footer_award_image_06.jpg" alt="2020 사랑나눔 사회공헌대상"></a></li>
+              <li><a href="javascript:void(0)"><img src="./images/footer_award_image_07.jpg" alt="CCM 인증획득"></a></li>
+            </ul>
+          </div>
+          <div class="footer-desktop__bottom">
+            <div class="footer-desktop__policy" aria-label="스타벅스 주요 정책 링크">
+              <a href="javascript:void(0)">개인정보처리방침</a>
+              <a href="javascript:void(0)">영상정보처리기기 운영관리 방침</a>
+              <a href="javascript:void(0)">홈페이지 이용약관</a>
+              <a href="javascript:void(0)">위치정보 이용약관</a>
+              <a href="javascript:void(0)">스타벅스 카드 이용약관</a>
+              <a href="javascript:void(0)">신세계 유니버스 클럽 이용약관</a>
+              <a href="javascript:void(0)">비회원 이용약관</a>
+              <a href="javascript:void(0)">My DT Pass 서비스 이용약관</a>
+              <a href="javascript:void(0)">윤리경영 핫라인</a>
+            </div>
+            <div class="footer-desktop__buttons" aria-label="스타벅스 푸터 바로가기">
+              <a href="javascript:void(0)">찾아오시는 길</a>
+              <a href="javascript:void(0)">신규입점제의</a>
+              <a href="javascript:void(0)">사이트 맵</a>
+            </div>
+            <div class="footer-desktop__info" aria-label="스타벅스 사업자 정보">
+              <p>사업자등록번호 : 201-81-21515</p>
+              <p>주식회사 에스씨케이컴퍼니 대표이사 : 손정현</p>
+              <p>TEL : 1522-3232</p>
+              <p>개인정보 책임자 : 이찬우</p>
+            </div>
+            <p class="footer-desktop__copyright">
+              &copy; <span class="this-year"></span> Starbucks Coffee Company. All Rights Reserved.
+            </p>
+          </div>
         </div>
       </div>
-      <div class="footer_awards_wrap">
-        <div class="footer_award_inner">
-          <ul class="footer_award_list">
-            <li><a href="javascript:void(0)"><img src="./images/footer_award_image_01.jpg" alt="2020 여성가족부장관상"></a></li>
-            <li><a href="javascript:void(0)"><img src="./images/footer_award_image_02.jpg" alt="2020 행정안전부장관 표창"></a></li>
-            <li><a href="javascript:void(0)"><img src="./images/footer_award_image_03.jpg" alt="2020 농림축산식품부 장관상"></a></li>
-            <li><a href="javascript:void(0)"><img src="./images/footer_award_image_04.jpg" alt="2020 대한민국 중소중견기업혁신대상"></a></li>
-            <li><a href="javascript:void(0)"><img src="./images/footer_award_image_05.jpg" alt="2020 대한민국 일자리 유공 표창"></a></li>
-            <li><a href="javascript:void(0)"><img src="./images/footer_award_image_06.jpg" alt="2020 사랑나눔 사회공헌대상"></a></li>
-            <li><a href="javascript:void(0)"><img src="./images/footer_award_image_07.jpg" alt="CCM 인증획득"></a></li>
-          </ul>
+
+      <!-- Mobile footer -->
+      <div class="mobile-flow-footer">
+        <div class="mobile-flow-footer__inner">
+          <section class="mobile-flow-footer__section mobile-flow-footer__section--service">
+            <h2 class="mobile-flow-footer__title">스타벅스를 이용해보세요</h2>
+            <ul class="mobile-flow-footer__list">
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">매장 찾기</a></li>
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">사이렌 오더</a></li>
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">딜리버스</a></li>
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">e-Gift Card</a></li>
+            </ul>
+          </section>
+          <section class="mobile-flow-footer__section mobile-flow-footer__section--menu">
+            <h2 class="mobile-flow-footer__title">메뉴와 커피를 더 알고 싶다면</h2>
+            <ul class="mobile-flow-footer__list">
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">음료</a></li>
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">푸드</a></li>
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">상품</a></li>
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">커피 이야기</a></li>
+            </ul>
+          </section>
+          <section class="mobile-flow-footer__section mobile-flow-footer__section--brand">
+            <h2 class="mobile-flow-footer__title">스타벅스가 궁금하다면</h2>
+            <ul class="mobile-flow-footer__list">
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">스타벅스 소개</a></li>
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">국내 뉴스룸</a></li>
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">사회공헌</a></li>
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">채용 소개</a></li>
+            </ul>
+          </section>
+          <section class="mobile-flow-footer__section mobile-flow-footer__section--support">
+            <h2 class="mobile-flow-footer__title">더 필요한 안내</h2>
+            <ul class="mobile-flow-footer__list">
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">공지사항</a></li>
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">고객의 소리</a></li>
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">자주 하는 질문</a></li>
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">매장 이용 안내</a></li>
+            </ul>
+          </section>
+          <div class="mobile-flow-footer__policy" aria-label="스타벅스 모바일 주요 정책 링크">
+            <a href="javascript:void(0)" class="mobile-flow-footer__link">개인정보처리방침</a>
+            <a href="javascript:void(0)" class="mobile-flow-footer__link">홈페이지 이용약관</a>
+            <a href="javascript:void(0)" class="mobile-flow-footer__link">위치정보 이용약관</a>
+            <a href="javascript:void(0)" class="mobile-flow-footer__link">스타벅스 카드 이용약관</a>
+          </div>
+          <div class="mobile-flow-footer__info" aria-label="스타벅스 사업자 정보">
+            <p>사업자등록번호 : 201-81-21515</p>
+            <p>주식회사 에스씨케이컴퍼니 대표이사 : 손정현</p>
+            <p>TEL : 1522-3232</p>
+            <p>개인정보 책임자 : 이찬우</p>
+          </div>
+          <p class="mobile-flow-footer__copyright">
+            &copy; <span class="this-year"></span> Starbucks Coffee Company. All Rights Reserved.
+          </p>
         </div>
       </div>
-      <aside class="footer_util">
-        <a href="javascript:void(0)">개인정보처리방침</a>
-        <a href="javascript:void(0)">영상정보처리기기 운영관리 방침</a>
-        <a href="javascript:void(0)">홈페이지 이용약관</a>
-        <a href="javascript:void(0)">위치정보 이용약관</a>
-        <a href="javascript:void(0)">스타벅스 카드 이용약관</a>
-        <a href="javascript:void(0)">신세계 유니버스 클럽 이용약관</a>
-        <a href="javascript:void(0)">비회원 이용약관</a>
-        <a href="javascript:void(0)">My DT Pass 서비스 이용약관</a>
-        <a href="javascript:void(0)" class="last-child">윤리경영 핫라인</a>
-          <br>
-        <a href="javascript:void(0)" class="btned_link">찾아오시는 길</a>
-        <a href="javascript:void(0)" class="btned_link">신규입점제의</a>
-        <a href="javascript:void(0)" class="btned_link">사이트 맵</a>
-          <br>
-        <ul class="copy_menu">
-          <li>사업자등록번호 : 201-81-21515</li>
-          <li>주식회사 에스씨케이컴퍼니 대표이사 : 손정현</li>
-          <li>TEL : 1522-3232</li>
-          <li>개인정보 책임자 : 이찬우</li>
-        </ul>
-        <span class="end">
-          &copy; <span class="this-year"></span> Starbucks Coffee Company. All Rights Reserved.
-        </span>
-      </aside>
-
     </footer>
 
   </main>

--- a/js/common.js
+++ b/js/common.js
@@ -218,7 +218,10 @@ if (headerEl && headerToggleEl && headerCloseEls.length && headerOverlayEl) {
 }
 
 // Footer copyright
-const thisYear = document.querySelector('.this-year');
-if (thisYear) {
-    thisYear.textContent = new Date().getFullYear();
+const thisYearEls = document.querySelectorAll('.this-year');
+if (thisYearEls.length) {
+    const currentYear = new Date().getFullYear();
+    thisYearEls.forEach(function (thisYearEl) {
+        thisYearEl.textContent = currentYear;
+    });
 }

--- a/js/common.js
+++ b/js/common.js
@@ -74,13 +74,14 @@ if (searchEl && searchInputEl) {
 
 // Responsive header GNB logic
 const headerEl = document.querySelector('header');
-const headerNavEl = headerEl ? headerEl.querySelector('.header-nav') : null;
 const headerToggleEl = headerEl ? headerEl.querySelector('.header-toggle') : null;
 const headerCloseEls = headerEl ? headerEl.querySelectorAll('.header-close') : [];
+const headerCloseActionEls = headerEl ? headerEl.querySelectorAll('.header-nav__close-action') : [];
 const headerOverlayEl = headerEl ? headerEl.querySelector('.header-overlay') : null;
 const headerMenuButtons = headerEl ? headerEl.querySelectorAll('.main-menu .item > .item__name') : [];
 const tabletMediaQuery = window.matchMedia('(max-width: 959px)');
 const rootEl = document.documentElement;
+const headerActionsVisibleClass = 'is-nav-actions-visible';
 
 function syncHeaderNavViewportHeight() {
     if (!rootEl) {
@@ -95,16 +96,12 @@ function syncHeaderNavViewportHeight() {
     rootEl.style.setProperty('--header-nav-height', window.innerHeight + 'px');
 }
 
-function closeHeaderNav() {
-    if (!headerEl || !headerToggleEl) {
+function resetHeaderMenuState() {
+    if (!headerEl) {
         return;
     }
 
-    headerEl.classList.remove('is-nav-open');
-    headerEl.classList.remove('is-bottom-close-visible');
-    document.body.classList.remove('header-nav-open');
-    headerToggleEl.setAttribute('aria-expanded', 'false');
-    resetSearchFocusState();
+    headerEl.classList.remove(headerActionsVisibleClass);
 
     headerMenuButtons.forEach(function (buttonEl) {
         const itemEl = buttonEl.closest('.item');
@@ -115,31 +112,23 @@ function closeHeaderNav() {
     });
 }
 
+function closeHeaderNav() {
+    if (!headerEl || !headerToggleEl) {
+        return;
+    }
+
+    headerEl.classList.remove('is-nav-open');
+    document.body.classList.remove('header-nav-open');
+    headerToggleEl.setAttribute('aria-expanded', 'false');
+    resetSearchFocusState();
+    resetHeaderMenuState();
+}
+
 function syncHeaderNavState() {
     if (!tabletMediaQuery.matches) {
         closeHeaderNav();
         headerEl.classList.remove('is-nav-ready');
     }
-}
-
-function syncBottomCloseVisibility() {
-    if (!headerEl || !headerNavEl) {
-        return;
-    }
-
-    if (!tabletMediaQuery.matches || !headerEl.classList.contains('is-nav-open')) {
-        headerEl.classList.remove('is-bottom-close-visible');
-        return;
-    }
-
-    const scrollableDistance = headerNavEl.scrollHeight - headerNavEl.clientHeight;
-    if (scrollableDistance <= 24) {
-        headerEl.classList.remove('is-bottom-close-visible');
-        return;
-    }
-
-    const isNearBottom = headerNavEl.scrollTop + headerNavEl.clientHeight >= headerNavEl.scrollHeight - 24;
-    headerEl.classList.toggle('is-bottom-close-visible', isNearBottom);
 }
 
 if (headerEl && headerToggleEl && headerCloseEls.length && headerOverlayEl) {
@@ -150,22 +139,18 @@ if (headerEl && headerToggleEl && headerCloseEls.length && headerOverlayEl) {
         document.body.classList.toggle('header-nav-open', isOpen);
         headerToggleEl.setAttribute('aria-expanded', String(isOpen));
 
-        if (!isOpen) {
-            headerEl.classList.remove('is-bottom-close-visible');
-            headerMenuButtons.forEach(function (buttonEl) {
-                const itemEl = buttonEl.closest('.item');
-                if (itemEl) {
-                    itemEl.classList.remove('is-open');
-                }
-                buttonEl.setAttribute('aria-expanded', 'false');
-            });
+        if (isOpen) {
+            headerEl.classList.remove(headerActionsVisibleClass);
         } else {
-            window.requestAnimationFrame(syncBottomCloseVisibility);
+            resetHeaderMenuState();
         }
     });
 
     headerCloseEls.forEach(function (closeButtonEl) {
         closeButtonEl.addEventListener('click', closeHeaderNav);
+    });
+    headerCloseActionEls.forEach(function (closeActionEl) {
+        closeActionEl.addEventListener('click', closeHeaderNav);
     });
     headerOverlayEl.addEventListener('click', closeHeaderNav);
 
@@ -191,25 +176,18 @@ if (headerEl && headerToggleEl && headerCloseEls.length && headerOverlayEl) {
             if (itemEl && !isOpen) {
                 itemEl.classList.add('is-open');
                 buttonEl.setAttribute('aria-expanded', 'true');
+                headerEl.classList.add(headerActionsVisibleClass);
             }
-
-            window.requestAnimationFrame(syncBottomCloseVisibility);
         });
     });
 
-    if (headerNavEl) {
-        headerNavEl.addEventListener('scroll', syncBottomCloseVisibility, { passive: true });
-    }
     window.addEventListener('resize', syncHeaderNavState);
     window.addEventListener('resize', syncHeaderNavViewportHeight);
-    window.addEventListener('resize', syncBottomCloseVisibility);
     if (window.visualViewport) {
         window.visualViewport.addEventListener('resize', syncHeaderNavViewportHeight);
-        window.visualViewport.addEventListener('resize', syncBottomCloseVisibility);
     }
     syncHeaderNavState();
     syncHeaderNavViewportHeight();
-    syncBottomCloseVisibility();
     document.addEventListener('keydown', function (event) {
         if (event.key === 'Escape') {
             closeHeaderNav();

--- a/js/main.js
+++ b/js/main.js
@@ -1,19 +1,21 @@
 // badge 컨트롤 gsap
 const badgeEl = document.querySelector('aside .badges');
 
-window.addEventListener('scroll', _.throttle(function () {
-  if (window.scrollY > 500) {
-    gsap.to(badgeEl, 0.6, {
-      opacity: 0,
-      display: 'none'
-    });
-  } else {
-    gsap.to(badgeEl, 0.6, {
-      opacity: 1,
-      display: 'block'
-    });
-  }
-}, 300));
+if (badgeEl && typeof gsap !== 'undefined' && typeof _ !== 'undefined') {
+  window.addEventListener('scroll', _.throttle(function () {
+    if (window.scrollY > 500) {
+      gsap.to(badgeEl, 0.6, {
+        opacity: 0,
+        display: 'none'
+      });
+    } else {
+      gsap.to(badgeEl, 0.6, {
+        opacity: 1,
+        display: 'block'
+      });
+    }
+  }, 300));
+}
 
 /** Hero fade sequence **/
 const heroFadeMediaQuery = window.matchMedia('(max-width: 950px)');
@@ -220,17 +222,37 @@ if (orderChoiceEl && orderChoicePanelEl && orderChoiceTriggerEls.length) {
 /** What's New Swiper **/
 const whatsNewSectionEl = document.querySelector('.whats-new');
 const whatsNewPaginationEl = whatsNewSectionEl ? whatsNewSectionEl.querySelector('.whats-new__pagination') : null;
+const whatsNewSlideEls = whatsNewSectionEl ? whatsNewSectionEl.querySelectorAll('.whats-new__swiper .whats-new__slide') : [];
+
+function getWhatsNewTotalSlides(swiper) {
+  if (whatsNewSectionEl) {
+    const originalSlideEls = whatsNewSectionEl.querySelectorAll('.whats-new__swiper .whats-new__slide:not(.swiper-slide-duplicate)');
+    if (originalSlideEls.length) {
+      return originalSlideEls.length;
+    }
+  }
+
+  if (whatsNewSlideEls.length) {
+    return whatsNewSlideEls.length;
+  }
+
+  return swiper && swiper.slides ? swiper.slides.length : 0;
+}
 
 function updateWhatsNewPagination(swiper) {
   if (!whatsNewPaginationEl) {
     return;
   }
 
-  const totalSlides = swiper.slides.length - (swiper.loopedSlides * 2);
-  whatsNewPaginationEl.textContent = (swiper.realIndex + 1) + '/' + totalSlides;
+  const totalSlides = getWhatsNewTotalSlides(swiper);
+  const currentSlide = totalSlides
+    ? ((swiper.realIndex % totalSlides) + totalSlides) % totalSlides + 1
+    : 0;
+
+  whatsNewPaginationEl.textContent = currentSlide + '/' + totalSlides;
 }
 
-if (whatsNewSectionEl) {
+if (whatsNewSectionEl && typeof Swiper !== 'undefined') {
   const whatsNewSwiper = new Swiper('.whats-new .swiper-container', {
     loop: true,
     slidesPerView: 'auto',
@@ -252,56 +274,64 @@ if (whatsNewSectionEl) {
   updateWhatsNewPagination(whatsNewSwiper);
 }
 
-new Swiper('.notice-line .swiper-container', {
-  direction: 'vertical',
-  autoplay: true,
-  loop: true
-});
+if (document.querySelector('.notice-line .swiper-container') && typeof Swiper !== 'undefined') {
+  new Swiper('.notice-line .swiper-container', {
+    direction: 'vertical',
+    autoplay: true,
+    loop: true
+  });
+}
 
 // promotion Swiper 시즌 프로모션 슬라이더
-new Swiper('.promotion .swiper-container', {
-  autoplay: {
-    delay: 3000,
-    disableOnInteraction: true
-  },
-  loop: true,
-  slidesPerView: 3,
-  spaceBetween: 10,
-  centeredSlides: true,
-  pagination: {
-    el: '.promotion .swiper-pagination',
-    clickable: true,
-    type: 'bullets'
-  },
-  navigation: {
-    prevEl: '.promotion .swiper-prev',
-    nextEl: '.promotion .swiper-next'
-  }
-});
+if (document.querySelector('.promotion .swiper-container') && typeof Swiper !== 'undefined') {
+  new Swiper('.promotion .swiper-container', {
+    autoplay: {
+      delay: 3000,
+      disableOnInteraction: true
+    },
+    loop: true,
+    slidesPerView: 3,
+    spaceBetween: 10,
+    centeredSlides: true,
+    pagination: {
+      el: '.promotion .swiper-pagination',
+      clickable: true,
+      type: 'bullets'
+    },
+    navigation: {
+      prevEl: '.promotion .swiper-prev',
+      nextEl: '.promotion .swiper-next'
+    }
+  });
+}
 
 /** Promotion 슬라이드 토글 기능 **/
 const noticeEl = document.querySelector('.notice');
-const toggleMenuEl = noticeEl.querySelector('.menu-toggler');
+const toggleMenuEl = noticeEl ? noticeEl.querySelector('.menu-toggler') : null;
 const promotionEl = document.querySelector('.promotion');
 const promotionToggleBtn = document.querySelector('.toggle-promotion');
 let isHidePromotion = false;
 
-promotionToggleBtn.addEventListener('click', function () {
-  isHidePromotion = !isHidePromotion;
-  if (isHidePromotion) {
-    promotionEl.classList.remove('hide');
-  } else {
-    promotionEl.classList.add('hide');
-  }
-});
+if (promotionEl && promotionToggleBtn) {
+  promotionToggleBtn.addEventListener('click', function () {
+    isHidePromotion = !isHidePromotion;
+    if (isHidePromotion) {
+      promotionEl.classList.remove('hide');
+    } else {
+      promotionEl.classList.add('hide');
+    }
+  });
+}
 
-toggleMenuEl.addEventListener('click', function () {
-  if (noticeEl.classList.contains('menuing')) {
-    hideNoticeProMenu();
-  } else {
-    showNoticeProMenu();
-  }
-});
+if (noticeEl && toggleMenuEl) {
+  toggleMenuEl.addEventListener('click', function () {
+    if (noticeEl.classList.contains('menuing')) {
+      hideNoticeProMenu();
+    } else {
+      showNoticeProMenu();
+    }
+  });
+}
 
 function showNoticeProMenu() {
   noticeEl.classList.add('menuing');
@@ -313,11 +343,13 @@ function hideNoticeProMenu() {
 
 // event triggerHook
 const spyEls = document.querySelectorAll('section.scroll-spy');
-spyEls.forEach(function (spyEl) {
-  new ScrollMagic.Scene({
-    triggerElement: spyEl,
-    triggerHook: 0.8
-  })
-    .setClassToggle(spyEl, 'show')
-    .addTo(new ScrollMagic.Controller());
-});
+if (spyEls.length && typeof ScrollMagic !== 'undefined') {
+  spyEls.forEach(function (spyEl) {
+    new ScrollMagic.Scene({
+      triggerElement: spyEl,
+      triggerHook: 0.8
+    })
+      .setClassToggle(spyEl, 'show')
+      .addTo(new ScrollMagic.Controller());
+  });
+}

--- a/signup/index.html
+++ b/signup/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="format-detection" content="telephone=no, date=no, address=no, email=no">
   <title>Starbucks Korea</title>
 
   <meta property="og:type" content="website" />
@@ -54,24 +55,41 @@
               <span class="material-icons" aria-hidden="true">close</span>
               <span class="blind">전체 메뉴 닫기</span>
             </button>
+            <div class="header-quick-links" aria-label="빠른 이동">
+              <a href="https://www.starbucks.co.kr/store/store_map.do" class="header-quick-link">
+                <span class="material-icons header-quick-link__icon" aria-hidden="true">place</span>
+                <span class="header-quick-link__text">매장 찾기</span>
+              </a>
+              <a href="https://www.starbucks.co.kr/menu/drink_list.do" class="header-quick-link">
+                <span class="material-icons header-quick-link__icon" aria-hidden="true">local_cafe</span>
+                <span class="header-quick-link__text">메뉴</span>
+              </a>
+              <a href="./" class="header-quick-link">
+                <span class="material-icons header-quick-link__icon" aria-hidden="true">person</span>
+                <span class="header-quick-link__text">로그인</span>
+              </a>
+            </div>
             <div class="sub-menu">
             <ul class="menu">
               <li>
-                <a href="./index.html">Sign In</a>  
+                <a href="./">Sign In</a>  
               </li>
               <li>
-                <a href="javascript:void(0)">My Starbucks</a>
+                <a href="https://www.starbucks.co.kr/msr/msreward/about.do">My Starbucks</a>
               </li>
               <li>
-                <a href="javascript:void(0)">Customer Service & ideas</a>
+                <a href="https://www.starbucks.co.kr/util/index.do">Customer Service & ideas</a>
               </li>
               <li>
-                <a href="javascript:void(0)">Find a Store</a>
+                <a href="https://www.starbucks.co.kr/store/store_map.do">Find a Store</a>
               </li>
             </ul>
-            <div class="search" role="button" aria-label="통합검색">
-              <input type="text">
-              <span class="material-icons">search</span>
+            <div class="search">
+              <input type="text" placeholder="통합검색" aria-label="통합검색">
+              <span class="material-icons search__icon" aria-hidden="true">search</span>
+              <button type="button" class="search__clear" aria-label="검색어 지우기">
+                <span class="material-icons" aria-hidden="true">close</span>
+              </button>
             </div>
           </div>
           </div>
@@ -86,6 +104,7 @@
                       <ul>
                         <li>스타벅스 원두</li>
                         <li>스타벅스 비아</li>
+                        <li>스타벅스 오리가미</li>
                         <li>스타벅스앳홈 by 캡슐</li>
                         <li>나와 어울리는 커피</li>
                       </ul>
@@ -95,7 +114,7 @@
                       <ul>
                         <li>농장에서 우리의 손으로</li>
                         <li>최상의 아라비카 원두</li>
-                        <li>스타벅스 로스트 스팩트럼</li>
+                        <li>스타벅스 로스트 스펙트럼</li>
                         <li>스타벅스 디카페인</li>
                       </ul>
                     </li>
@@ -181,14 +200,14 @@
                       <h2>카드</h2>
                       <ul>
                         <li>실물카드</li>
-                        <li>e-Gift 카드</li>
+                        <li>스타벅스 모바일 카드</li>
                       </ul>
                     </li>
                     <li>
                       <h2>메뉴 이야기</h2>
                       <ul>
-                        <li>콜드 브루</li>
                         <li>스타벅스 티바나</li>
+                        <li>스타벅스 콜드 브루</li>
                       </ul>
                     </li>
                   </ul>
@@ -205,7 +224,7 @@
                       <ul>
                         <li>퀵 검색</li>
                         <li>지역 검색</li>
-                        <li>My 매장</li>
+                        <li><a href="javascript:void(0)">My 매장</a></li>
                       </ul>
                     </li>
                     <li>
@@ -237,7 +256,7 @@
                         <li>커뮤니티 스토어</li>
                         <li>청젼 지원 프로그램</li>
                         <li>우리 농산물 사랑 캠페인</li>
-                        <li>우리 문화 지키기</li>
+                        <li>국가유산 지킴이 활동</li>
                       </ul>
                     </li>
                     <li>
@@ -269,7 +288,7 @@
               </div>
             </li>
             <li class="item">
-              <button class="item__name" type="button" aria-expanded="false">MY STARBUCKS REWARDS</button>
+              <button class="item__name" type="button" aria-expanded="false">STARBUCKS REWARDS</button>
               <div class="item__contents">
                 <div class="contents__menu">
                   <ul class="inner">
@@ -287,16 +306,13 @@
                       <ul>
                         <li>스타벅스 카드 소개</li>
                         <li>스타벅스 카드 갤러리</li>
-                        <li>등록 및 조회</li>
-                        <li>충전 및 이용안내</li>
-                        <li>분실신고/환불신청</li>
                         <li>자주하는 질문</li>
                       </ul>
                     </li>
                     <li>
-                      <h2>스타벅스 카드 e-Gift</h2>
+                      <h2>스타벅스 모바일 카드</h2>
                       <ul>
-                        <li>스타벅스 카드 e-Gift 소개</li>
+                        <li>스타벅스 모바일 카드 소개</li>
                         <li>이용안내</li>
                         <li>선물하기</li>
                         <li>자주하는 질문</li>
@@ -314,10 +330,10 @@
                     <li>
                       <h2>단체 및 기업 구매 안내</h2>
                       <ul>
-                        <li>md상품</li>
+                        <li>MD상품</li>
                         <li>실물카드</li>
-                        <li>e-Gift Card(MMS)</li>
-                        <li>e-Gift Card(BULK)</li>
+                        <li>스타벅스 모바일 카드(MMS)</li>
+                        <li>스타벅스 모바일 카드(BULK)</li>
                       </ul>
                     </li>
                     <li>
@@ -332,7 +348,7 @@
                 </div>
               </div>
             </li>
-            <li class="item">
+            <li class="item item--whats-new">
               <button class="item__name" type="button" aria-expanded="false">WHAT'S NEW</button>
               <div class="item__contents">
                 <div class="contents__menu">
@@ -342,7 +358,7 @@
                       <ul>
                         <li>전체</li>
                         <li>스타벅스 카드</li>
-                        <li>마이 스타벅스 리워드</li>
+                        <li>스타벅스 리워드</li>
                         <li>온라인</li>
                       </ul>
                     </li>
@@ -351,7 +367,7 @@
                       <ul>
                         <li>전체</li>
                         <li>상품 출시</li>
-                        <li>스타벅스의 문화</li>
+                        <li>스타벅스와 문화</li>
                         <li>스타벅스 사회공헌</li>
                         <li>스타벅스 카드출시</li>
                       </ul>
@@ -374,6 +390,9 @@
               </div>
             </li>
           </ul>
+          <div class="header-nav__actions">
+            <button type="button" class="header-nav__close-action">메뉴 닫기</button>
+          </div>
           </div>
       </div>
       <div class="header-overlay"></div>

--- a/signup/index.html
+++ b/signup/index.html
@@ -402,84 +402,154 @@
         </div>
     </section>
     <!-- 푸터 -->
-    <footer id="footer">
-
-      <div class="footer_wrap">
-        <div class="footer_menus" role="footerGroup" aria-labelledby="Group-label">
-          <ul class="first_menu">
-            <li><a href="javascript:void(0)" role="link">company</a></li>
-            <li><a href="javascript:void(0)">한눈에보기</a></li>
-            <li><a href="javascript:void(0)">스타벅스 사명</a></li>
-            <li><a href="javascript:void(0)">스타벅스 소개</a></li>
-            <li><a href="javascript:void(0)">컴플라이언스</a></li>
-            <li><a href="javascript:void(0)">국내 뉴스룸</a></li>
-            <li><a href="javascript:void(0)">세계의 스타벅스</a></li>
-            <li><a href="javascript:void(0)">글로벌 뉴스룸</a></li>
-          </ul>
-          <ul class="second_menu">
-            <li><a href="javascript:void(0)" role="link">corporate sales</a></li>
-            <li><a href="javascript:void(0)">단체 및 기업 구매 안내</a></li>
-            <li><a href="javascript:void(0)">단체 주문 배달 안내</a></li>
-          </ul>
-          <ul class="third_menu">
-            <li><a href="javascript:void(0)" role="link">partnership</a></li>
-            <li><a href="javascript:void(0)">신규 입점 제의</a></li>
-            <li><a href="javascript:void(0)">협력 고객사 등록신청</a></li>
-            <li><a href="javascript:void(0)">중개업체 확인</a></li>
-          </ul>
-          <ul class="fourth_menu">
-            <li><a href="javascript:void(0)" role="link">online community</a></li>
-            <li><a href="javascript:void(0)">페이스북</a></li>
-            <li><a href="javascript:void(0)">트위터</a></li>
-            <li><a href="javascript:void(0)">유튜브</a></li>
-            <li><a href="javascript:void(0)">인스타그램</a></li>
-          </ul>
-          <ul class="fifth_menu">
-            <li><a href="javascript:void(0)" role="link">recruit</a></li>
-            <li><a href="javascript:void(0)">채용 소개</a></li>
-            <li><a href="javascript:void(0)">채용 지원하기</a></li>
-          </ul>
+    <footer id="footer" class="footer">
+      <!-- Desktop footer -->
+      <div class="footer-desktop">
+        <div class="footer-desktop__inner">
+          <div class="footer-desktop__top">
+            <nav class="footer-desktop__menu" aria-label="스타벅스 데스크탑 푸터 메뉴">
+              <section class="footer-desktop__menu-group">
+                <h2 class="footer-desktop__menu-title">Company</h2>
+                <ul class="footer-desktop__menu-list">
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">한눈에 보기</a></li>
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">스타벅스 사명</a></li>
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">스타벅스 소개</a></li>
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">컴플라이언스</a></li>
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">국내 뉴스룸</a></li>
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">세계의 스타벅스</a></li>
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">글로벌 뉴스룸</a></li>
+                </ul>
+              </section>
+              <section class="footer-desktop__menu-group">
+                <h2 class="footer-desktop__menu-title">Corporate Sales</h2>
+                <ul class="footer-desktop__menu-list">
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">단체 및 기업 구매 안내</a></li>
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">단체 주문 배달 안내</a></li>
+                </ul>
+              </section>
+              <section class="footer-desktop__menu-group">
+                <h2 class="footer-desktop__menu-title">Partnership</h2>
+                <ul class="footer-desktop__menu-list">
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">신규 입점 제의</a></li>
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">협력 고객사 등록신청</a></li>
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">중개업체 확인</a></li>
+                </ul>
+              </section>
+              <section class="footer-desktop__menu-group">
+                <h2 class="footer-desktop__menu-title">Online Community</h2>
+                <ul class="footer-desktop__menu-list">
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">페이스북</a></li>
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">트위터</a></li>
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">유튜브</a></li>
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">인스타그램</a></li>
+                </ul>
+              </section>
+              <section class="footer-desktop__menu-group">
+                <h2 class="footer-desktop__menu-title">Recruit</h2>
+                <ul class="footer-desktop__menu-list">
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">채용 소개</a></li>
+                  <li class="footer-desktop__menu-item"><a href="javascript:void(0)" class="footer-desktop__menu-link">채용 지원하기</a></li>
+                </ul>
+              </section>
+            </nav>
+          </div>
+          <div class="footer-desktop__awards" aria-label="스타벅스 수상 내역">
+            <ul>
+              <li><a href="javascript:void(0)"><img src="../images/footer_award_image_01.jpg" alt="2020 여성가족부장관상"></a></li>
+              <li><a href="javascript:void(0)"><img src="../images/footer_award_image_02.jpg" alt="2020 행정안전부장관 표창"></a></li>
+              <li><a href="javascript:void(0)"><img src="../images/footer_award_image_03.jpg" alt="2020 농림축산식품부 장관상"></a></li>
+              <li><a href="javascript:void(0)"><img src="../images/footer_award_image_04.jpg" alt="2020 대한민국 중소중견기업혁신대상"></a></li>
+              <li><a href="javascript:void(0)"><img src="../images/footer_award_image_05.jpg" alt="2020 대한민국 일자리 유공 표창"></a></li>
+              <li><a href="javascript:void(0)"><img src="../images/footer_award_image_06.jpg" alt="2020 사랑나눔 사회공헌대상"></a></li>
+              <li><a href="javascript:void(0)"><img src="../images/footer_award_image_07.jpg" alt="CCM 인증획득"></a></li>
+            </ul>
+          </div>
+          <div class="footer-desktop__bottom">
+            <div class="footer-desktop__policy" aria-label="스타벅스 주요 정책 링크">
+              <a href="javascript:void(0)">개인정보처리방침</a>
+              <a href="javascript:void(0)">영상정보처리기기 운영관리 방침</a>
+              <a href="javascript:void(0)">홈페이지 이용약관</a>
+              <a href="javascript:void(0)">위치정보 이용약관</a>
+              <a href="javascript:void(0)">스타벅스 카드 이용약관</a>
+              <a href="javascript:void(0)">신세계 유니버스 클럽 이용약관</a>
+              <a href="javascript:void(0)">비회원 이용약관</a>
+              <a href="javascript:void(0)">My DT Pass 서비스 이용약관</a>
+              <a href="javascript:void(0)">윤리경영 핫라인</a>
+            </div>
+            <div class="footer-desktop__buttons" aria-label="스타벅스 푸터 바로가기">
+              <a href="javascript:void(0)">찾아오시는 길</a>
+              <a href="javascript:void(0)">신규입점제의</a>
+              <a href="javascript:void(0)">사이트 맵</a>
+            </div>
+            <div class="footer-desktop__info" aria-label="스타벅스 사업자 정보">
+              <p>사업자등록번호 : 201-81-21515</p>
+              <p>주식회사 에스씨케이컴퍼니 대표이사 : 손정현</p>
+              <p>TEL : 1522-3232</p>
+              <p>개인정보 책임자 : 이찬우</p>
+            </div>
+            <p class="footer-desktop__copyright">
+              &copy; <span class="this-year"></span> Starbucks Coffee Company. All Rights Reserved.
+            </p>
+          </div>
         </div>
       </div>
-      <div class="footer_awards_wrap">
-        <div class="footer_award_inner">
-          <ul class="footer_award_list">
-            <li><a href="javascript:void(0)"><img src="../images/footer_award_image_01.jpg" alt="2020 여성가족부장관상"></a></li>
-            <li><a href="javascript:void(0)"><img src="../images/footer_award_image_02.jpg" alt="2020 행정안전부장관 표창"></a></li>
-            <li><a href="javascript:void(0)"><img src="../images/footer_award_image_03.jpg" alt="2020 농림축산식품부 장관상"></a></li>
-            <li><a href="javascript:void(0)"><img src="../images/footer_award_image_04.jpg" alt="2020 대한민국 중소중견기업혁신대상"></a></li>
-            <li><a href="javascript:void(0)"><img src="../images/footer_award_image_05.jpg" alt="2020 대한민국 일자리 유공 표창"></a></li>
-            <li><a href="javascript:void(0)"><img src="../images/footer_award_image_06.jpg" alt="2020 사랑나눔 사회공헌대상"></a></li>
-            <li><a href="javascript:void(0)"><img src="../images/footer_award_image_07.jpg" alt="CCM 인증획득"></a></li>
-          </ul>
+
+      <!-- Mobile footer -->
+      <div class="mobile-flow-footer">
+        <div class="mobile-flow-footer__inner">
+          <section class="mobile-flow-footer__section mobile-flow-footer__section--service">
+            <h2 class="mobile-flow-footer__title">스타벅스를 이용해보세요</h2>
+            <ul class="mobile-flow-footer__list">
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">매장 찾기</a></li>
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">사이렌 오더</a></li>
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">딜리버스</a></li>
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">e-Gift Card</a></li>
+            </ul>
+          </section>
+          <section class="mobile-flow-footer__section mobile-flow-footer__section--menu">
+            <h2 class="mobile-flow-footer__title">메뉴와 커피를 더 알고 싶다면</h2>
+            <ul class="mobile-flow-footer__list">
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">음료</a></li>
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">푸드</a></li>
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">상품</a></li>
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">커피 이야기</a></li>
+            </ul>
+          </section>
+          <section class="mobile-flow-footer__section mobile-flow-footer__section--brand">
+            <h2 class="mobile-flow-footer__title">스타벅스가 궁금하다면</h2>
+            <ul class="mobile-flow-footer__list">
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">스타벅스 소개</a></li>
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">국내 뉴스룸</a></li>
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">사회공헌</a></li>
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">채용 소개</a></li>
+            </ul>
+          </section>
+          <section class="mobile-flow-footer__section mobile-flow-footer__section--support">
+            <h2 class="mobile-flow-footer__title">더 필요한 안내</h2>
+            <ul class="mobile-flow-footer__list">
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">공지사항</a></li>
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">고객의 소리</a></li>
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">자주 하는 질문</a></li>
+              <li class="mobile-flow-footer__item"><a href="javascript:void(0)" class="mobile-flow-footer__link">매장 이용 안내</a></li>
+            </ul>
+          </section>
+          <div class="mobile-flow-footer__policy" aria-label="스타벅스 모바일 주요 정책 링크">
+            <a href="javascript:void(0)" class="mobile-flow-footer__link">개인정보처리방침</a>
+            <a href="javascript:void(0)" class="mobile-flow-footer__link">홈페이지 이용약관</a>
+            <a href="javascript:void(0)" class="mobile-flow-footer__link">위치정보 이용약관</a>
+            <a href="javascript:void(0)" class="mobile-flow-footer__link">스타벅스 카드 이용약관</a>
+          </div>
+          <div class="mobile-flow-footer__info" aria-label="스타벅스 사업자 정보">
+            <p>사업자등록번호 : 201-81-21515</p>
+            <p>주식회사 에스씨케이컴퍼니 대표이사 : 손정현</p>
+            <p>TEL : 1522-3232</p>
+            <p>개인정보 책임자 : 이찬우</p>
+          </div>
+          <p class="mobile-flow-footer__copyright">
+            &copy; <span class="this-year"></span> Starbucks Coffee Company. All Rights Reserved.
+          </p>
         </div>
       </div>
-      <aside class="footer_util">
-        <a href="javascript:void(0)">개인정보처리방침</a>
-        <a href="javascript:void(0)">영상정보처리기기 운영관리 방침</a>
-        <a href="javascript:void(0)">홈페이지 이용약관</a>
-        <a href="javascript:void(0)">위치정보 이용약관</a>
-        <a href="javascript:void(0)">스타벅스 카드 이용약관</a>
-        <a href="javascript:void(0)">신세계 유니버스 클럽 이용약관</a>
-        <a href="javascript:void(0)">비회원 이용약관</a>
-        <a href="javascript:void(0)">My DT Pass 서비스 이용약관</a>
-        <a href="javascript:void(0)" class="last-child">윤리경영 핫라인</a>
-          <br>
-        <a href="javascript:void(0)" class="btned_link">찾아오시는 길</a>
-        <a href="javascript:void(0)" class="btned_link">신규입점제의</a>
-        <a href="javascript:void(0)" class="btned_link">사이트 맵</a>
-          <br>
-        <ul class="copy_menu">
-          <li>사업자등록번호 : 201-81-21515</li>
-          <li>주식회사 에스씨케이컴퍼니 대표이사 : 손정현</li>
-          <li>TEL : 1522-3232</li>
-          <li>개인정보 책임자 : 이찬우</li>
-        </ul>
-        <span class="end">
-          &copy; <span class="this-year"></span> Starbucks Coffee Company. All Rights Reserved.
-        </span>
-      </aside>
-
     </footer>
 
   </main>


### PR DESCRIPTION
## 작업 내용

- footer desktop / mobile 구조를 분리해 리뉴얼 방향에 맞게 정리
- 모바일 footer 정보 구조를 사용자 중심 카테고리로 재구성
- footer 타이틀, 링크 간격, 하단 정책/정보 영역의 가독성 보정
- 모바일 nav에서 기존 하단 도달 기반 floating close 방식 대신
  하단 sticky close action 방식으로 정리
- 메뉴 탐색 시작 이후 하단 닫기 액션이 보이도록 UX 흐름 조정
- 관련 CSS / JS 정리 및 불필요한 하단 노출 로직 제거

## 작업 이유

- 모바일에서 footer와 nav의 정보 구조 및 닫기 동선을 더 자연스럽게 개선하기 위해
- 순수 HTML/CSS/JS 기반 프로젝트에서 유지보수 가능하고 설명 가능한 구조로 정리하기 위해

## 확인 포인트

- footer mobile / desktop 구분이 의도대로 적용되는지
- footer 타이틀 및 링크 가독성이 이전보다 개선되었는지
- 모바일 nav에서 아코디언 탐색 이후 하단 닫기 액션이 자연스럽게 보이는지
- 기존 floating close 방식 제거 이후 UX가 더 안정적인지