### PR TITLE
refactor: 데스크탑 비쥬얼섹션 이미지 배치 정리

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -160,9 +160,6 @@
   }
 }
 
-.visual .visual_stage__group {
-  display: contents;
-}
 
 /* =========================================================
    #first_reserve 섹션대응 구조 조정 후 미디어쿼리 | 951px ~ 1279px
@@ -295,11 +292,6 @@
   }
 }
 
-/* =========================================================
-   비쥬얼 섹션 미디어 쿼리
-   절대배치로 인해 대응이 안 되는 구간
-   재조정 후 미디어 쿼리 재작성
-========================================================= */
 @media screen and (min-width: 950px) and (max-width: 1279px) {
   .visual {
     padding-left: 14px;
@@ -307,95 +299,115 @@
   }
 
   .visual .visual-inner {
-    height: clamp(430px, 35vw, 540px);
+    height: clamp(430px, 24vw, 540px);
     min-height: 430px;
     max-height: 540px;
+    /* 재수정 */
+    background-position: center top;
+    background-size: 100% auto;
   }
 
   .visual .visual_slogan,
   .visual .btn_slogan {
-    left: 7.2%;
-    width: 25.8%;
+    left: 7.5%;
+    width: 24%;
   }
 
   .visual .visual_slogan {
-    top: 32.6%;
+    top: 31.5%;
   }
 
   .visual .btn_slogan {
-    top: 57.4%;
+    top: 56%;
   }
 
   .visual .btn_slogan a {
-    min-width: 132px;
-    width: auto;
-    padding: 0 18px;
+    min-width: 120px;
     height: 36px;
+    padding: 0 18px;
     font-size: 13px;
+  }
+
+  .visual .visual_stage {
+    position: relative;
+    width: 100%;
+    height: 100%;
   }
 
   .visual .visual_stage__group {
     position: absolute;
-    display: flex;
-    align-items: flex-start;
-    justify-content: flex-start;
+    display: block;
     margin: 0;
     padding: 0;
-    transform: none;
   }
 
   .visual .visual_stage__group--left {
-    top: 27.6%;
-    left: 40%;
-    width: 21.6%;
+    top: 17%;
+    left: 39%;
+    width: 24%;
+    height: 60%;
+  }
+
+  .visual .visual_stage__group--center {
+    top: 30%;
+    left: 55.5%;
+    width: 12%;
+    height: 40%;
   }
 
   .visual .visual_stage__group--right {
-    top: 27%;
-    left: 57%;
-    width: 33.2%;
+    top: 16.5%;
+    left: 61.5%;
+    width: 25%;
+    height: 60%;
   }
 
   .visual .visual_stage__item {
-    position: relative;
-    top: auto;
-    right: auto;
-    bottom: auto;
-    left: auto;
-    flex: 0 0 auto;
+    position: absolute;
     margin: 0;
-    transform: none;
   }
 
-  .visual .visual_stage__item--drink-01 {
-    z-index: 10;
-    width: 57%;
+  .visual .visual_stage__group--left .visual_stage__item--drink-01 {
+    top: 0;
+    left: 0;
+    width: 50%;
   }
 
-  .visual .visual_stage__item--drink-02 {
-    z-index: 10;
-    width: 60%;
-    margin-left: -12%;
-    margin-top: clamp(18px, 1.6vw, 24px);
+  .visual .visual_stage__group--left .visual_stage__item--drink-02 {
+    top: 1%;
+    left: 35%;
+    width: 48%;
   }
 
-  .visual .visual_stage__item--drink-03 {
-    z-index: 10;
-    width: 43%;
+  .visual .visual_stage__group--left .visual_stage__item--drink-03 {
+    top: 35%;
+    left: 18%;
+    width: 44%;
   }
 
-  .visual .visual_stage__item--drink-04 {
-    z-index: 9;
-    width: 36%;
-    margin-left: -11%;
+  .visual .visual_stage__group--center .visual_stage__item--drink-07 {
+    top: 0;
+    left: 0;
+    width: 100%;
   }
 
-  .visual .visual_stage__item--drink-05 {
-    z-index: 8;
-    width: 35%;
-    margin-left: -9%;
+  .visual .visual_stage__group--right .visual_stage__item--drink-04 {
+    top: 0;
+    left: 0;
+    width: 42%;
   }
 
+  .visual .visual_stage__group--right .visual_stage__item--drink-05 {
+    top: 0;
+    left: 35%;
+    width: 42%;
+  }
+
+  .visual .visual_stage__group--right .visual_stage__item--drink-06 {
+    top: 35%;
+    left: 15%;
+    width: 48%;
+  }
 }
 
 /* =========================================================

--- a/css/style.css
+++ b/css/style.css
@@ -374,8 +374,8 @@ aside .badges img {
   .visual .visual_slogan,
   .visual .btn_slogan {
     position: absolute;
-    left: 11.4%;
-    width: 23.5%;
+    left: 10%;
+    width: 20%;
     margin: 0;
   }
 
@@ -392,10 +392,10 @@ aside .badges img {
 
   .visual .btn_slogan {
     top: 59.29%;
-    left: 11.35%;
+    left: 10%;
     z-index: 4;
     text-align: center;
-    width: 23.5%;
+    width: 20%;
   }
 
   .visual .btn_slogan a {
@@ -462,222 +462,56 @@ aside .badges img {
 
   .visual .visual_stage__item--drink-02 {
     z-index: 10;
-    top: 26.471%;
+    top: 17%;
     left: 44.4%;
     width: 10.95%;
   }
 
   .visual .visual_stage__item--drink-03 {
     z-index: 10;
-    top: 16.874%;
-    left: 50.7%;
-    width: 13.5%;
+    top: 47%;
+    left: 33%;
+    width: 18%;
   }
 
   .visual .visual_stage__item--drink-04 {
-    z-index: 9;
-    top: 16.874%;
-    left: 62%;
-    width: 11.15%;
+    z-index: 10;
+    top: 17%;
+    left: 60%;
+    width: 10.95%;
   }
 
   .visual .visual_stage__item--drink-05 {
-    z-index: 8;
+    z-index: 11;
     top: 16.874%;
     left: 70.2%;
-    width: 11.5%;
+    width: 10.95%;
+  }
+    .visual .visual_stage__item--drink-06 {
+    z-index: 12;
+    top: 47%;
+    left: 65%;
+    width: 18%;
+  }
+    .visual .visual_stage__item--drink-07 {
+    z-index: 13;
+    top: 25.5%;
+    left: 50%;
+    width: 13%;
   }
 
   .visual .visual_stage__item--drink-01,
   .visual .visual_stage__item--drink-02,
   .visual .visual_stage__item--drink-03,
   .visual .visual_stage__item--drink-04,
-  .visual .visual_stage__item--drink-05 {
+  .visual .visual_stage__item--drink-05,
+  .visual .visual_stage__item--drink-06,
+  .visual .visual_stage__item--drink-07 {
     margin-bottom: 0 !important;
   }
-.visual [data-hero-fade] {
-  opacity: 0;
-}
-
-/* season-drinks legacy desktop styles
-.season-drinks {
-  position: relative;
-  overflow: hidden;
-  padding: 104px 24px 112px;
-  background: linear-gradient(180deg, rgba(244, 232, 241, .94) 0%, rgba(255, 250, 247, .98) 14%, #fbf7f0 44%, #f6f1e8 100%);
-}
-.season-drinks__inner {
-  position: relative;
-  max-width: 1280px;
-  margin: 0 auto;
-}
-.season-drinks__heading {
-  max-width: 720px;
-  margin-bottom: 46px;
-  padding-left: 4px;
-}
-.season-drinks__eyebrow {
-  margin: 0 0 12px;
-  color: #7e63ab;
-  font-size: 14px;
-  font-weight: 700;
-  letter-spacing: .14em;
-  text-transform: uppercase;
-}
-.season-drinks__heading h2 {
-  margin: 0;
-  color: #1e3932;
-  font-size: clamp(32px, 3vw, 44px);
-  line-height: 1.12;
-}
-.season-drinks__heading p {
-  margin: 14px 0 0;
-  max-width: 60ch;
-  color: #5a615f;
-  font-size: 16px;
-  line-height: 1.72;
-}
-.season-drinks__grid {
-  display: grid;
-  Desktop showcase: one lead card + four supporting cards
-  grid-template-columns: minmax(250px, 1.28fr) repeat(4, minmax(170px, 1fr));
-  grid-auto-flow: row;
-  gap: 18px;
-  row-gap: 24px;
-  align-items: stretch;
-  width: 100%;
-}
-.season-drinks__card {
-  position: relative;
-  grid-column: span 1;
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-  min-width: 0;
-  height: auto;
-  padding: 22px 18px 20px;
-  border-radius: 30px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, .82) 0%, rgba(253, 250, 246, .95) 100%);
-  border: 1px solid rgba(255, 255, 255, .82);
-  box-shadow: 0 16px 30px rgba(99, 84, 118, .06);
-  overflow: hidden;
-  align-self: stretch;
-}
-.season-drinks__card::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(180deg, rgba(255, 255, 255, .3) 0%, rgba(255, 255, 255, 0) 28%);
-  pointer-events: none;
-}
-.season-drinks__card--featured {
-  grid-column: span 1;
-  background: linear-gradient(180deg, rgba(255, 255, 255, .92) 0%, rgba(246, 249, 241, .96) 50%, rgba(249, 245, 235, .98) 100%);
-  box-shadow: 0 18px 34px rgba(30, 57, 50, .08);
-}
-.season-drinks__visual {
-  position: relative;
-  Desktop visual stage: rounded square so the product image has enough presence
-  height: auto;
-  aspect-ratio: 1 / 1;
-  padding: 0;
-  border-radius: 24px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, .34) 0%, rgba(255, 246, 249, .8) 62%, rgba(250, 247, 240, .96) 100%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden;
-}
-.season-drinks__visual::after {
-  display: none;
-}
-.season-drinks__visual picture,
-.season-drinks__visual img {
-  display: block;
-  width: 100%;
-}
-.season-drinks__visual picture {
-  display: block;
-  height: 100%;
-  overflow: hidden;
-  border-radius: inherit;
-}
-.season-drinks__visual img {
-  width: 100%;
-  height: 100%;
-  max-width: none;
-  max-height: none;
-  margin: 0;
-  object-fit: contain;
-  object-position: center center;
-  transform: scale(1.08);
-  transform-origin: center center;
-}
-.season-drinks__card--featured .season-drinks__visual img {
-  transform: scale(1.04);
-}
-.season-drinks__copy {
-  Copy rhythm: keep title/description/button on a stable vertical grid
-  display: grid;
-  grid-template-rows: auto minmax(calc(1.62em * 3), 1fr) auto;
-  flex: 1;
-  align-items: start;
-  gap: 12px;
-  min-height: 0;
-  padding-top: 16px;
-}
-.season-drinks__card--featured .season-drinks__copy {
-  grid-template-rows: auto minmax(calc(1.62em * 3), 1fr) auto;
-}
-.season-drinks__copy h3 {
-  margin: 0;
-  color: #1e3932;
-  font-size: 19px;
-  line-height: 1.22;
-  letter-spacing: -.03em;
-  min-height: 2.44em;
-}
-.season-drinks__card--featured .season-drinks__copy h3 {
-  font-size: 23px;
-  min-height: 2.34em;
-}
-.season-drinks__copy p {
-  margin: 0;
-  color: #5a615f;
-  font-size: 14px;
-  line-height: 1.62;
-  min-height: calc(1.62em * 3);
-  display: -webkit-box;
-  overflow: hidden;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
-}
-.season-drinks__copy a {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: fit-content;
-  min-width: 118px;
-  height: 42px;
-  margin-top: 2px;
-  position: relative;
-  z-index: 1;
-  padding: 0 20px;
-  border-radius: 999px;
-  border: 1px solid rgba(0, 98, 65, .16);
-  background-color: rgba(255, 255, 255, .66);
-  color: #006241;
-  font-size: 13px;
-  font-weight: 700;
-  text-decoration: none;
-  transition: background-color .3s ease, color .3s ease, border-color .3s ease;
-}
-.season-drinks__copy a:hover {
-  background-color: #006241;
-  border-color: #006241;
-  color: #fff;
-}
-*/
+  .visual [data-hero-fade] {
+    opacity: 0;
+  }
 
 /* whats-new
    - season-drinks 대체 영역

--- a/index.html
+++ b/index.html
@@ -482,37 +482,40 @@
               <div class="visual_stage__item visual_stage__item--drink-01" data-hero-fade data-fade-desktop-order="3">
                 <div class="visual_stage__box">
                   <picture>
-                    <source media="(max-width: 950px)" srcset="https://image.istarbucks.co.kr/upload/common/img/main/2026/2026_spring1_ph1_top_drink01_mo_260220.png">
-                    <img src="https://image.istarbucks.co.kr/upload/common/img/main/2026/2026_spring1_ph1_top_drink01_260220.png" alt="슈크림 라떼">
+                    <img src="https://image.istarbucks.co.kr/upload/common/img/main/2026/2026_spring2_top_drink04_260407.png" alt="슈크림 라떼">
                   </picture>
                 </div>
               </div>
-
               <div class="visual_stage__item visual_stage__item--drink-02" data-hero-fade data-fade-desktop-order="4">
                 <div class="visual_stage__box">
                   <picture>
-                    <source media="(max-width: 950px)" srcset="https://image.istarbucks.co.kr/upload/common/img/main/2026/2026_spring1_ph1_top_drink02_mo_260220.png">
-                    <img src="https://image.istarbucks.co.kr/upload/common/img/main/2026/2026_spring1_ph1_top_drink02_260220.png" alt="슈 폼 라떼">
+                    <img src="https://image.istarbucks.co.kr/upload/common/img/main/2026/2026_spring2_top_drink05_260407.png" alt="슈 폼 라떼">
+                  </picture>
+                </div>
+              </div>
+              <div class="visual_stage__item visual_stage__item--drink-03" data-hero-fade data-fade-desktop-order="5">
+                <div class="visual_stage__box">
+                  <picture>
+                    <img src="https://image.istarbucks.co.kr/upload/common/img/main/2026/2026_spring2_top_drink02_260407.png" alt="버즈 키위 팝 에너지 피지오">
                   </picture>
                 </div>
               </div>
             </div>
-
-            <div class="visual_stage__group visual_stage__group--right">
-              <div class="visual_stage__item visual_stage__item--drink-03" data-hero-fade data-fade-desktop-order="5" data-fade-mobile-order="2">
+             <div class="visual_stage__group visual_stage__group--center">
+              <div class="visual_stage__item visual_stage__item--drink-07" data-hero-fade data-fade-desktop-order="9">
                 <div class="visual_stage__box">
                   <picture>
-                    <source media="(max-width: 950px)" srcset="https://image.istarbucks.co.kr/upload/common/img/main/2026/2026_spring2_top_drink01_mo_260407.png">
-                    <img src="https://image.istarbucks.co.kr/upload/common/img/main/2026/2026_spring1_ph1_top_drink03_260220.png" alt="슈크림 말차 라떼">
+                    <source media="(max-width: 950px)" srcset="https://image.istarbucks.co.kr/upload/common/img/main/2026/2026_spring1_ph1_top_drink02_mo_260220.png">
+                    <img src="https://image.istarbucks.co.kr/upload/common/img/main/2026/2026_spring2_top_drink01_260407.png" alt="우디 카우보이 쿠키 콜드 브루">
                   </picture>
                 </div>
               </div>
-
-              <div class="visual_stage__item visual_stage__item--drink-04" data-hero-fade data-fade-desktop-order="6">
+             </div>
+            <div class="visual_stage__group visual_stage__group--right">
+              <div class="visual_stage__item visual_stage__item--drink-04" data-hero-fade data-fade-desktop-order="6" data-fade-mobile-order="2">
                 <div class="visual_stage__box">
                   <picture>
-                    <source media="(max-width: 950px)" srcset="https://image.istarbucks.co.kr/upload/common/img/main/2026/2026_spring1_ph1_top_drink04_mo_260220.png">
-                    <img src="https://image.istarbucks.co.kr/upload/common/img/main/2026/2026_spring1_ph1_top_drink04_260220.png" alt="슈크림 딸기 라떼">
+                    <img src="https://image.istarbucks.co.kr/upload/common/img/main/2026/2026_spring2_top_drink07_260407.png" alt="슈 폼 말차 라떼">
                   </picture>
                 </div>
               </div>
@@ -520,8 +523,15 @@
               <div class="visual_stage__item visual_stage__item--drink-05" data-hero-fade data-fade-desktop-order="7">
                 <div class="visual_stage__box">
                   <picture>
-                    <source media="(max-width: 950px)" srcset="https://image.istarbucks.co.kr/upload/common/img/main/2026/2026_spring1_ph1_top_drink05_mo_260220.png">
-                    <img src="https://image.istarbucks.co.kr/upload/common/img/main/2026/2026_spring1_ph1_top_drink05_260220.png" alt="체리 블라썸 백도 크림 프라푸치노">
+                    <img src="https://image.istarbucks.co.kr/upload/common/img/main/2026/2026_spring2_top_drink06_260407.png" alt="슈크림 말차 라떼">
+                  </picture>
+                </div>
+              </div>
+
+              <div class="visual_stage__item visual_stage__item--drink-06" data-hero-fade data-fade-desktop-order="8">
+                <div class="visual_stage__box">
+                  <picture>
+                    <img src="https://image.istarbucks.co.kr/upload/common/img/main/2026/2026_spring2_top_drink03_260407.png" alt="제시 슈트로베리 프라푸치노">
                   </picture>
                 </div>
               </div>
@@ -573,133 +583,6 @@
         </div>
       </div>
     </section>
-
-    <!-- season-drinks legacy markup
-    <section class="season-drinks" id="season_drinks">
-      <div class="season-drinks__inner">
-        <div class="season-drinks__heading">
-          <p class="season-drinks__eyebrow">Spring Drinks</p>
-          <h2>올 봄의 무드를 한 컵씩 만나보세요.</h2>
-          <p>
-            Hero에서 먼저 본 대표 음료를 중심으로, 시즌 전체 라인업을 가볍게 둘러보고
-            취향에 맞는 메뉴를 골라보세요.
-          </p>
-        </div>
-
-        <div class="season-drinks__grid">
-          <article class="season-drinks__card season-drinks__card--featured">
-            <div class="season-drinks__visual">
-              <picture>
-                <source media="(max-width: 540px)" srcset="https://image.istarbucks.co.kr/upload/store/skuimg/2026/02/[9200000005912]_20260205133333178.jpg">
-                <img src="https://image.istarbucks.co.kr/upload/store/skuimg/2026/02/[9200000005912]_20260205133333178.jpg" alt="슈크림 말차 라떼">
-              </picture>
-            </div>
-            <div class="season-drinks__copy">
-              <h3>슈크림 말차 라떼</h3>
-              <p>깊은 말차 풍미에 슈크림 무드를 더한 시즌 대표 라떼.</p>
-              <a
-                href="https://www.starbucks.co.kr/menu/drink_list.do"
-                class="season-drinks__order-trigger"
-                data-order-trigger="season-drink"
-                role="button"
-                aria-haspopup="dialog"
-                aria-controls="order_choice_layer">
-                주문하러 가기
-              </a>
-            </div>
-          </article>
-
-          <article class="season-drinks__card">
-            <div class="season-drinks__visual">
-              <picture>
-                <source media="(max-width: 540px)" srcset="https://image.istarbucks.co.kr/upload/store/skuimg/2026/02/[9200000000418]_20260205104039381.jpg">
-                <img src="https://image.istarbucks.co.kr/upload/store/skuimg/2026/02/[9200000000418]_20260205104039381.jpg" alt="슈크림 라떼">
-              </picture>
-            </div>
-            <div class="season-drinks__copy">
-              <h3>슈크림 라떼</h3>
-              <p>에스프레소와 슈크림 풍미가 어우러진 클래식 시즌 라떼.</p>
-              <a
-                href="https://www.starbucks.co.kr/menu/drink_list.do"
-                class="season-drinks__order-trigger"
-                data-order-trigger="season-drink"
-                role="button"
-                aria-haspopup="dialog"
-                aria-controls="order_choice_layer">
-                주문하러 가기
-              </a>
-            </div>
-          </article>
-
-          <article class="season-drinks__card">
-            <div class="season-drinks__visual">
-              <picture>
-                <source media="(max-width: 540px)" srcset="https://image.istarbucks.co.kr/upload/store/skuimg/2026/02/[9200000006787]_20260205111102166.jpg">
-                <img src="https://image.istarbucks.co.kr/upload/store/skuimg/2026/02/[9200000006787]_20260205111102166.jpg" alt="슈 폼 라떼">
-              </picture>
-            </div>
-            <div class="season-drinks__copy">
-              <h3>슈 폼 라떼</h3>
-              <p>가벼운 슈 폼으로 산뜻하게 즐기는 시즌 라떼 스타일.</p>
-              <a
-                href="https://www.starbucks.co.kr/menu/drink_list.do"
-                class="season-drinks__order-trigger"
-                data-order-trigger="season-drink"
-                role="button"
-                aria-haspopup="dialog"
-                aria-controls="order_choice_layer">
-                주문하러 가기
-              </a>
-            </div>
-          </article>
-
-          <article class="season-drinks__card">
-            <div class="season-drinks__visual">
-              <picture>
-                <source media="(max-width: 540px)" srcset="https://image.istarbucks.co.kr/upload/store/skuimg/2026/02/[9200000006814]_20260205133905689.jpg">
-                <img src="https://image.istarbucks.co.kr/upload/store/skuimg/2026/02/[9200000006814]_20260205133905689.jpg" alt="슈크림 딸기 라떼">
-              </picture>
-            </div>
-            <div class="season-drinks__copy">
-              <h3>슈크림 딸기 라떼</h3>
-              <p>딸기의 산뜻함과 슈크림의 부드러움을 담은 봄 한정 음료.</p>
-              <a
-                href="https://www.starbucks.co.kr/menu/drink_list.do"
-                class="season-drinks__order-trigger"
-                data-order-trigger="season-drink"
-                role="button"
-                aria-haspopup="dialog"
-                aria-controls="order_choice_layer">
-                주문하러 가기
-              </a>
-            </div>
-          </article>
-
-          <article class="season-drinks__card">
-            <div class="season-drinks__visual">
-              <picture>
-                <source media="(max-width: 540px)" srcset="https://image.istarbucks.co.kr/upload/store/skuimg/2026/02/[9200000006835]_20260205134040309.jpg">
-                <img src="https://image.istarbucks.co.kr/upload/store/skuimg/2026/02/[9200000006835]_20260205134040309.jpg" alt="체리 블라썸 백도 크림 프라푸치노">
-              </picture>
-            </div>
-            <div class="season-drinks__copy">
-              <h3>체리 블라썸 백도 크림 프라푸치노</h3>
-              <p>백도의 향긋함과 크림 무드가 어우러진 시즌 프라푸치노.</p>
-              <a
-                href="https://www.starbucks.co.kr/menu/drink_list.do"
-                class="season-drinks__order-trigger"
-                data-order-trigger="season-drink"
-                role="button"
-                aria-haspopup="dialog"
-                aria-controls="order_choice_layer">
-                주문하러 가기
-              </a>
-            </div>
-          </article>
-        </div>
-      </div>
-    </section>
-    -->
 
     <!-- season-drinks 대체: 모바일에서만 노출되는 What’s New 카드 슬라이드 -->
     <section class="whats-new" aria-labelledby="whats_new_title">


### PR DESCRIPTION
## 작업 내용

* 메인 hero 음료 배치 스프링 프로모션 추가로 재정비
* 기존 구조를 유지한 채 리소스 추가 후 데스크탑 absolute 배치 조정
* 좌측 카피와 우측 음료 군집의 균형 보정

## 변경 파일

* `index.html`
* `css/style.css`
* `css/app.css`

## 목적

기능 추가보다 데스크탑 hero의 시각적 완성도와 유지보수성을 높이기 위한 리팩터링입니다.

## 확인 포인트

* 데스크탑에서 음료군이 하나의 프로모션 비주얼처럼 보이는지
* 공홈 대비 과도하게 비거나 깨지는 구간이 없는지

## 메모

* 데스크탑 기준 1차 정리 완료
* 중간 반응형 구간은 후속 보정 필요함
* 해당 브랜치에서 자원 최신화와 반응형을 마무리 할 예정
<img width="1906" height="667" alt="image" src="https://github.com/user-attachments/assets/dfbff6e6-cc14-450a-a44a-87760e0c1ce2" />

