### PR TITLE
포트폴리오 인트로 스플래시 추가

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -21,6 +21,128 @@
   outline-offset: 6px;
 }
 
+body.is-splash-active {
+  overflow: hidden;
+}
+
+.splash-seen .portfolio-splash {
+  display: none;
+}
+
+.portfolio-splash {
+  position: fixed;
+  inset: 0;
+  z-index: 20000;
+  display: grid;
+  place-items: center;
+  padding: 32px;
+  background:
+    linear-gradient(115deg, rgba(255, 255, 255, 0.035) 0 1px, transparent 1px 100%),
+    linear-gradient(145deg, rgba(0, 41, 30, 0.97), rgba(7, 15, 13, 0.99) 68%),
+    #07100d;
+  background-size: 22px 22px, auto, auto;
+  color: #fff;
+  opacity: 1;
+  visibility: visible;
+  transition: opacity 0.55s ease, visibility 0.55s ease;
+}
+
+.portfolio-splash.is-hidden {
+  opacity: 0;
+  visibility: hidden;
+}
+
+.portfolio-splash__inner {
+  position: relative;
+  width: min(100%, 620px);
+  padding-left: 28px;
+  text-align: left;
+}
+
+.portfolio-splash__inner::before {
+  content: "";
+  position: absolute;
+  top: 4px;
+  bottom: 5px;
+  left: 0;
+  width: 2px;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(216, 197, 143, 0.9), rgba(0, 168, 98, 0.34));
+}
+
+.portfolio-splash__eyebrow {
+  margin-bottom: 16px;
+  color: rgba(216, 197, 143, 0.84);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.portfolio-splash__title {
+  color: #fff;
+  font-size: 46px;
+  font-weight: 700;
+  line-height: 1.08;
+}
+
+.portfolio-splash__copy {
+  margin-top: 22px;
+  color: rgba(255, 255, 255, 0.92);
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1.58;
+  word-break: keep-all;
+}
+
+.portfolio-splash__desc {
+  max-width: 540px;
+  margin-top: 10px;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 14px;
+  line-height: 1.75;
+  word-break: keep-all;
+}
+
+.portfolio-splash__progress {
+  overflow: hidden;
+  height: 6px;
+  margin-top: 40px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background-color: rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.portfolio-splash__progress-fill {
+  display: block;
+  width: 0%;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #d8c58f 0%, #00a862 72%, #31c986 100%);
+  box-shadow: 0 0 18px rgba(0, 168, 98, 0.28);
+  transition: width 0.1s linear;
+}
+
+.portfolio-splash__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 18px;
+  margin-top: 15px;
+  color: rgba(255, 255, 255, 0.66);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.portfolio-splash__meta strong {
+  flex-shrink: 0;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
 [data-link-status="planned"] {
   cursor: default;
 }
@@ -44,6 +166,41 @@
 @media screen and (max-width: 950px) {
   #main_content {
     scroll-margin-top: 96px;
+  }
+}
+
+@media screen and (max-width: 640px) {
+  .portfolio-splash {
+    padding: 24px;
+  }
+
+  .portfolio-splash__inner {
+    padding-left: 20px;
+  }
+
+  .portfolio-splash__title {
+    font-size: 34px;
+  }
+
+  .portfolio-splash__copy {
+    font-size: 16px;
+  }
+
+  .portfolio-splash__desc {
+    font-size: 13px;
+  }
+
+  .portfolio-splash__meta {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .portfolio-splash,
+  .portfolio-splash__progress-fill {
+    transition-duration: 0.01ms;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -6,6 +6,20 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="format-detection" content="telephone=no, date=no, address=no, email=no">
   <title>Starbucks Korea</title>
+  <script>
+    try {
+      if (sessionStorage.getItem('starbucksPortfolioSplashSeen') === 'true') {
+        document.documentElement.classList.add('splash-seen');
+      }
+    } catch (error) {}
+  </script>
+  <noscript>
+    <style>
+      .portfolio-splash {
+        display: none;
+      }
+    </style>
+  </noscript>
 
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Starbucks" />
@@ -80,10 +94,33 @@
   <!--Lodash-->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.20/lodash.min.js" integrity="sha512-90vH1Z83AJY9DmlWa8WkjkV79yfS2n2Oxhsi2dZbIv0nC4E6m5AbH8Nh156kkM7JePmqD6tcZsfad1ueoaovww==" crossorigin="anonymous"></script>
   <script defer src="./js/common.js"></script>
+  <script defer src="./js/splash.js"></script>
   <script defer src="./js/main.js"></script>
 
 </head>
 <body>
+  <div class="portfolio-splash" id="portfolio-splash" data-splash>
+    <div class="portfolio-splash__inner" aria-labelledby="portfolio-splash-title" aria-describedby="portfolio-splash-desc">
+      <p class="portfolio-splash__eyebrow">Portfolio UI/UX Study</p>
+      <p class="portfolio-splash__title" id="portfolio-splash-title">Starbucks App Renewal</p>
+      <p class="portfolio-splash__copy">스타벅스 공홈을 참고해 재해석한 개인 웹 포트폴리오 프로젝트</p>
+      <p class="portfolio-splash__desc" id="portfolio-splash-desc">공식 사이트가 아닌, 브랜드 구조와 UX를 분석해 새롭게 구성한 데모 프로젝트입니다.</p>
+      <div
+        class="portfolio-splash__progress"
+        role="progressbar"
+        aria-label="인트로 로딩 진행률"
+        aria-valuemin="0"
+        aria-valuemax="100"
+        aria-valuenow="0">
+        <span class="portfolio-splash__progress-fill" data-splash-bar></span>
+      </div>
+      <div class="portfolio-splash__meta">
+        <span data-splash-status aria-live="polite">Preparing portfolio experience...</span>
+        <strong data-splash-progress>0%</strong>
+      </div>
+    </div>
+  </div>
+
   <nav class="skip-links" aria-label="바로가기">
     <a href="./signup/" class="skip-link">로그인 바로가기</a>
     <a href="#main-menu-first-item" class="skip-link" data-skip-menu>메뉴 바로가기</a>

--- a/js/splash.js
+++ b/js/splash.js
@@ -1,0 +1,124 @@
+(function () {
+    const splashEl = document.querySelector('[data-splash]');
+    if (!splashEl) {
+        return;
+    }
+
+    const storageKey = 'starbucksPortfolioSplashSeen';
+    const progressTextEl = splashEl.querySelector('[data-splash-progress]');
+    const progressBarEl = splashEl.querySelector('[data-splash-bar]');
+    const progressEl = splashEl.querySelector('[role="progressbar"]');
+    const statusEl = splashEl.querySelector('[data-splash-status]');
+    const mainEl = document.querySelector('main');
+    const skipLinksEl = document.querySelector('.skip-links');
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    let hasFinished = false;
+
+    function hasSeenSplash() {
+        try {
+            return sessionStorage.getItem(storageKey) === 'true';
+        } catch (error) {
+            return false;
+        }
+    }
+
+    function rememberSplash() {
+        try {
+            sessionStorage.setItem(storageKey, 'true');
+        } catch (error) {}
+    }
+
+    function setProgress(value) {
+        const safeValue = Math.max(0, Math.min(100, Math.round(value)));
+
+        if (progressTextEl) {
+            progressTextEl.textContent = safeValue + '%';
+        }
+
+        if (progressBarEl) {
+            progressBarEl.style.width = safeValue + '%';
+        }
+
+        if (progressEl) {
+            progressEl.setAttribute('aria-valuenow', String(safeValue));
+        }
+    }
+
+    function restorePage() {
+        if (hasFinished) {
+            return;
+        }
+
+        hasFinished = true;
+        document.body.classList.remove('is-splash-active');
+
+        if (mainEl) {
+            mainEl.inert = false;
+        }
+
+        if (skipLinksEl) {
+            skipLinksEl.inert = false;
+        }
+
+        splashEl.setAttribute('aria-hidden', 'true');
+        splashEl.remove();
+    }
+
+    function finishSplash() {
+        setProgress(100);
+        rememberSplash();
+
+        if (statusEl) {
+            statusEl.textContent = 'Portfolio experience ready.';
+        }
+
+        window.setTimeout(function () {
+            splashEl.classList.add('is-hidden');
+            splashEl.addEventListener('transitionend', restorePage, { once: true });
+            window.setTimeout(restorePage, 700);
+        }, reduceMotion ? 120 : 430);
+    }
+
+    if (hasSeenSplash()) {
+        document.documentElement.classList.add('splash-seen');
+        restorePage();
+        return;
+    }
+
+    document.body.classList.add('is-splash-active');
+
+    if (mainEl) {
+        mainEl.inert = true;
+    }
+
+    if (skipLinksEl) {
+        skipLinksEl.inert = true;
+    }
+
+    if (reduceMotion) {
+        setProgress(100);
+        finishSplash();
+        return;
+    }
+
+    const duration = 2200;
+    const startTime = window.performance.now();
+
+    function tick(now) {
+        const elapsed = now - startTime;
+        const ratio = Math.min(elapsed / duration, 1);
+        const eased = 1 - Math.pow(1 - ratio, 3);
+
+        setProgress(eased * 100);
+
+        if (ratio < 1) {
+            window.requestAnimationFrame(tick);
+            return;
+        }
+
+        finishSplash();
+    }
+
+    setProgress(0);
+    window.requestAnimationFrame(tick);
+}());


### PR DESCRIPTION
## 작업 개요
첫 진입 시 프로젝트 정체성을 명확하게 전달할 수 있도록 포트폴리오 인트로 스플래시를 추가했습니다.

## 주요 변경 사항
- 인트로 스플래시 오버레이 UI 추가
- 프로젝트 소개 카피 반영
- 0~100% 프로그레스 연출 추가
- 스플래시 디테일 및 레이아웃 보정
- 포트폴리오 프로젝트 성격이 먼저 드러나도록 구성

## 기대 효과
- 공식 사이트와의 혼동 방지
- 공홈 참고 기반의 개인 포트폴리오 프로젝트 정체성 강화
- 첫 진입 경험 개선